### PR TITLE
move dependencies to scs fork

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,13 +6,13 @@ members = [
 	 "substratee-node-calls",
 	 "client",
 	 "stf",
-	 "application-crypto"
 ]
 
-[patch.'https://github.com/paritytech/substrate']
-sr-io = { git = "https://github.com/scs/substraTEE-node", rev = 'd4a057c5841796994b46b6b35de922ec5777fec5' }
-primitives = { git = "https://github.com/scs/substrate-api-client", package = 'substrate-primitives', rev = 'a1e82a08418dc5de0b6bd3bf016bcee004736441' }
-substrate-application-crypto = { path = "application-crypto"}
+# cargo bug https://github.com/rust-lang/cargo/issues/5478
+# forces us to add extra characters to github url, like introducing double slashes
+[patch.'https://github.com/scs/substrate']
+primitives = { git = "https://github.com/scs//substrate", package = 'substrate-primitives', tag = "substraTEE-M5.1" }
+substrate-application-crypto = { git = "https://github.com/scs//substrate", tag = "substraTEE-M5.1" }
 
 [patch.crates-io]
 ed25519-dalek = { git = "https://github.com/scs/ed25519-dalek.git", branch = "no_std_sgx" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,5 +14,12 @@ members = [
 primitives = { git = "https://github.com/scs//substrate", package = 'substrate-primitives', tag = "substraTEE-M5.1" }
 substrate-application-crypto = { git = "https://github.com/scs//substrate", tag = "substraTEE-M5.1" }
 
+[patch.'https://github.com/paritytech/substrate']
+primitives = { git = "https://github.com/scs//substrate", package = 'substrate-primitives', tag = "substraTEE-M5.1" }
+substrate-application-crypto = { git = "https://github.com/scs//substrate", tag = "substraTEE-M5.1" }
+
+[patch.'https://github.com/scs/substrate-api-client']
+primitives = { git = "https://github.com/scs//substrate", package = 'substrate-primitives', tag = "substraTEE-M5.1" }
+
 [patch.crates-io]
 ed25519-dalek = { git = "https://github.com/scs/ed25519-dalek.git", branch = "no_std_sgx" }

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -28,7 +28,7 @@ sgx_crypto_helper   = { rev = "v1.0.9",git = "https://github.com/baidu/rust-sgx-
 
 [dependencies.my_node_runtime]
 git = "https://github.com/scs/substraTEE-node"
-rev = "d4a057c5841796994b46b6b35de922ec5777fec5"
+rev = "acd97f49be1f691c35f567dd79f7391ce9554a9f"
 package = "substratee-node-runtime"
 features = ["no_global_allocator"]
 
@@ -43,31 +43,31 @@ path = "../substratee-node-calls"
 path = "../worker/worker-api"
 
 [dependencies.system]
-git = "https://github.com/paritytech/substrate"
+git = "https://github.com/scs/substrate"
 rev = "f17d023bbe179f15678ac9989f471c9b18917e17"
 package = "srml-system"
 
 [dependencies.primitives]
-git = "https://github.com/paritytech/substrate"
+git = "https://github.com/scs/substrate"
 rev = "f17d023bbe179f15678ac9989f471c9b18917e17"
 package = "substrate-primitives"
 
 [dependencies.node-primitives]
-git = "https://github.com/paritytech/substrate"
+git = "https://github.com/scs/substrate"
 rev = "f17d023bbe179f15678ac9989f471c9b18917e17"
 
 [dependencies.substrate-keyring]
-git = "https://github.com/paritytech/substrate"
+git = "https://github.com/scs/substrate"
 rev = "f17d023bbe179f15678ac9989f471c9b18917e17"
 
 [dependencies.runtime_primitives]
-git = "https://github.com/paritytech/substrate"
+git = "https://github.com/scs/substrate"
 rev = "f17d023bbe179f15678ac9989f471c9b18917e17"
 package = "sr-primitives"
 default-features = false
 
 [dependencies.indices]
-git = 'https://github.com/paritytech/substrate'
+git = 'https://github.com/scs/substrate'
 rev = 'f17d023bbe179f15678ac9989f471c9b18917e17'
 package = "srml-indices"
 

--- a/enclave/Cargo.toml
+++ b/enclave/Cargo.toml
@@ -71,7 +71,7 @@ features = ["dangerous_configuration"]
 [dependencies.sr-io]
 git = "https://github.com/scs/substraTEE-node"
 package = 'sr-io'
-rev = 'd4a057c5841796994b46b6b35de922ec5777fec5'
+rev = 'acd97f49be1f691c35f567dd79f7391ce9554a9f'
 default-features = false
 features = ["no_oom", "no_panic_handler", "sgx", "debug"]
 
@@ -86,13 +86,13 @@ package = "substrate-primitives"
 default-features = false
 
 [dependencies.runtime_primitives]
-git = 'https://github.com/paritytech/substrate'
+git = 'https://github.com/scs/substrate'
 rev = "f17d023bbe179f15678ac9989f471c9b18917e17"
 package = "sr-primitives"
 default-features = false
 
 [dependencies.rstd]
-git = 'https://github.com/paritytech/substrate'
+git = 'https://github.com/scs/substrate'
 rev = "f17d023bbe179f15678ac9989f471c9b18917e17"
 package = "sr-std"
 features = ["no_global_allocator"]
@@ -109,10 +109,12 @@ default-features = false
 features = ["sgx"]
 
 
-[patch.'https://github.com/paritytech/substrate']
-sr-io = { git = "https://github.com/scs/substraTEE-node", rev = 'd4a057c5841796994b46b6b35de922ec5777fec5' }
-substrate-primitives = { git = "https://github.com/scs/substrate-api-client", rev = 'a1e82a08418dc5de0b6bd3bf016bcee004736441'}
-substrate-application-crypto = { path = "../application-crypto"}
+# cargo bug https://github.com/rust-lang/cargo/issues/5478
+# forces us to add extra characters to github url, like introducing double slashes
+[patch.'https://github.com/scs/substrate']
+primitives = { git = "https://github.com/scs//substrate", package = 'substrate-primitives', tag = "substraTEE-M5.1" }
+substrate-application-crypto = { git = "https://github.com/scs//substrate", tag = "substraTEE-M5.1" }
+sr-io = { git = "https://github.com/scs/substraTEE-node", rev = 'acd97f49be1f691c35f567dd79f7391ce9554a9f' }
 srml-balances = { path = "./balances" }
 
 [patch.crates-io]

--- a/enclave/Cargo.toml
+++ b/enclave/Cargo.toml
@@ -80,8 +80,8 @@ git = "https://github.com/baidu/rust-sgx-sdk"
 rev = "v1.0.9"
 
 [dependencies.primitives]
-git = "https://github.com/scs/substrate-api-client"
-rev = 'a1e82a08418dc5de0b6bd3bf016bcee004736441'
+git = 'https://github.com/scs/substrate'
+rev = "f17d023bbe179f15678ac9989f471c9b18917e17"
 package = "substrate-primitives"
 default-features = false
 
@@ -112,24 +112,25 @@ features = ["sgx"]
 # cargo bug https://github.com/rust-lang/cargo/issues/5478
 # forces us to add extra characters to github url, like introducing double slashes
 [patch.'https://github.com/scs/substrate']
-primitives = { git = "https://github.com/scs//substrate", package = 'substrate-primitives', tag = "substraTEE-M5.1" }
-substrate-application-crypto = { git = "https://github.com/scs//substrate", tag = "substraTEE-M5.1" }
-sr-io = { git = "https://github.com/scs/substraTEE-node", rev = 'acd97f49be1f691c35f567dd79f7391ce9554a9f' }
-srml-balances = { path = "./balances" }
+primitives = { git = "https://github.com/scs//substrate", package = 'substrate-primitives', tag = "substraTEE-M5.1" , default-features = false }
+substrate-application-crypto = { git = "https://github.com/scs//substrate", tag = "substraTEE-M5.1", default-features = false }
+sr-io = { git = "https://github.com/scs/substraTEE-node", package = 'sr-io', rev = 'acd97f49be1f691c35f567dd79f7391ce9554a9f', default-features = false }
+sr-std = { git = "https://github.com/scs//substrate", tag = "substraTEE-M5.1", default-features = false }
 
-# workaround for above workaround
+
 [patch.'https://github.com/scs//substrate']
-sr-io = { git = "https://github.com/scs/substraTEE-node", rev = 'acd97f49be1f691c35f567dd79f7391ce9554a9f' }
-#bricks all: primitives = { git = "https://github.com/scs/substrate", package = 'substrate-primitives', tag = "substraTEE-M5.1" }
-
-[patch.'https://github.com/scs/substrate-api-client']
-substrate-primitives = { git = "https://github.com/scs/substrate", tag = "substraTEE-M5.1" }
+sr-io = { git = "https://github.com/scs/substraTEE-node", package = 'sr-io', rev = 'acd97f49be1f691c35f567dd79f7391ce9554a9f', default-features = false }
 
 [patch.'https://github.com/paritytech/substrate']
-primitives = { git = "https://github.com/scs//substrate", package = 'substrate-primitives', tag = "substraTEE-M5.1" }
-substrate-application-crypto = { git = "https://github.com/scs//substrate", tag = "substraTEE-M5.1" }
-sr-io = { git = "https://github.com/scs/substraTEE-node", rev = 'acd97f49be1f691c35f567dd79f7391ce9554a9f' }
-srml-balances = { path = "./balances" }
+primitives = { git = "https://github.com/scs//substrate", package = 'substrate-primitives', tag = "substraTEE-M5.1" , default-features = false }
+substrate-application-crypto = { git = "https://github.com/scs//substrate", tag = "substraTEE-M5.1" , default-features = false }
+sr-io = { git = "https://github.com/scs/substraTEE-node", package = 'sr-io', rev = 'acd97f49be1f691c35f567dd79f7391ce9554a9f' , default-features = false }
+sr-std = { git = "https://github.com/scs//substrate", tag = "substraTEE-M5.1", default-features = false }
+
+[patch.'https://github.com/scs/substrate-api-client']
+primitives = { git = "https://github.com/scs//substrate", package = 'substrate-primitives', tag = "substraTEE-M5.1" , default-features = false }
+sr-io = { git = "https://github.com/scs/substraTEE-node", package = 'sr-io', rev = 'acd97f49be1f691c35f567dd79f7391ce9554a9f', default-features = false }
+sr-std = { git = "https://github.com/scs//substrate", tag = "substraTEE-M5.1", default-features = false }
 
 [patch.crates-io]
 ed25519-dalek = { git = "https://github.com/scs/ed25519-dalek.git", branch = "no_std_sgx"}

--- a/enclave/Cargo.toml
+++ b/enclave/Cargo.toml
@@ -117,5 +117,19 @@ substrate-application-crypto = { git = "https://github.com/scs//substrate", tag 
 sr-io = { git = "https://github.com/scs/substraTEE-node", rev = 'acd97f49be1f691c35f567dd79f7391ce9554a9f' }
 srml-balances = { path = "./balances" }
 
+# workaround for above workaround
+[patch.'https://github.com/scs//substrate']
+sr-io = { git = "https://github.com/scs/substraTEE-node", rev = 'acd97f49be1f691c35f567dd79f7391ce9554a9f' }
+#bricks all: primitives = { git = "https://github.com/scs/substrate", package = 'substrate-primitives', tag = "substraTEE-M5.1" }
+
+[patch.'https://github.com/scs/substrate-api-client']
+substrate-primitives = { git = "https://github.com/scs/substrate", tag = "substraTEE-M5.1" }
+
+[patch.'https://github.com/paritytech/substrate']
+primitives = { git = "https://github.com/scs//substrate", package = 'substrate-primitives', tag = "substraTEE-M5.1" }
+substrate-application-crypto = { git = "https://github.com/scs//substrate", tag = "substraTEE-M5.1" }
+sr-io = { git = "https://github.com/scs/substraTEE-node", rev = 'acd97f49be1f691c35f567dd79f7391ce9554a9f' }
+srml-balances = { path = "./balances" }
+
 [patch.crates-io]
 ed25519-dalek = { git = "https://github.com/scs/ed25519-dalek.git", branch = "no_std_sgx"}

--- a/enclave/balances/Cargo.toml
+++ b/enclave/balances/Cargo.toml
@@ -14,27 +14,27 @@ sgx_types     = { rev = "v1.0.9", git = "https://github.com/baidu/rust-sgx-sdk"}
 sgx_log       = { package = "log", version = "0.4.7", git = "https://github.com/mesalock-linux/log-sgx"}
 
 [dependencies.rstd]
-git = 'https://github.com/paritytech/substrate'
+git = 'https://github.com/scs/substrate'
 rev = "f17d023bbe179f15678ac9989f471c9b18917e17"
 package = "sr-std"
 features = ["no_global_allocator"]
 default-features = false
 
 [dependencies.sr-primitives]
-git = 'https://github.com/paritytech/substrate'
+git = 'https://github.com/scs/substrate'
 rev = "f17d023bbe179f15678ac9989f471c9b18917e17"
 package = "sr-primitives"
 default-features = false
 
 [dependencies.support]
 default-features = false
-git = "https://github.com/paritytech/substrate"
+git = "https://github.com/scs/substrate"
 package = "srml-support"
 rev = "f17d023bbe179f15678ac9989f471c9b18917e17"
 
 [dependencies.system]
 default-features = false
-git = "https://github.com/paritytech/substrate"
+git = "https://github.com/scs/substrate"
 package = "srml-system"
 rev = "f17d023bbe179f15678ac9989f471c9b18917e17"
 

--- a/stf/Cargo.toml
+++ b/stf/Cargo.toml
@@ -30,56 +30,56 @@ default-features = false
 features = ["derive"]
 
 [dependencies.primitives]
-git = "https://github.com/scs/substrate-api-client"
+git = "https://github.com/scs/substrate"
 package = "substrate-primitives"
 default-features = false
 
 [dependencies.runtime_primitives]
-git = 'https://github.com/paritytech/substrate'
+git = 'https://github.com/scs/substrate'
 rev = "f17d023bbe179f15678ac9989f471c9b18917e17"
 package = "sr-primitives"
 default-features = false
 
 [dependencies.balances]
 default-features = false
-git = "https://github.com/paritytech/substrate"
+git = "https://github.com/scs/substrate"
 package = "srml-balances"
 rev = "f17d023bbe179f15678ac9989f471c9b18917e17"
 
 [dependencies.timestamp]
 default-features = false
-git = "https://github.com/paritytech/substrate"
+git = "https://github.com/scs/substrate"
 package = "srml-timestamp"
 rev = "f17d023bbe179f15678ac9989f471c9b18917e17"
 
 [dependencies.system]
 default-features = false
-git = "https://github.com/paritytech/substrate"
+git = "https://github.com/scs/substrate"
 package = "srml-system"
 rev = "f17d023bbe179f15678ac9989f471c9b18917e17"
 
 [dependencies.srml-support]
 default-features = false
-git = "https://github.com/paritytech/substrate"
+git = "https://github.com/scs/substrate"
 package = "srml-support"
 rev = "f17d023bbe179f15678ac9989f471c9b18917e17"
 
 [dependencies.indices]
 default-features = false
-git = "https://github.com/paritytech/substrate"
+git = "https://github.com/scs/substrate"
 package = "srml-indices"
 rev = "f17d023bbe179f15678ac9989f471c9b18917e17"
 
 [dependencies.version]
 default-features = false
-git = "https://github.com/paritytech/substrate"
+git = "https://github.com/scs/substrate"
 package = "sr-version"
 rev = "f17d023bbe179f15678ac9989f471c9b18917e17"
 
 [dependencies.sr-io]
 git = "https://github.com/scs/substraTEE-node"
 package = 'sr-io'
-rev = 'd4a057c5841796994b46b6b35de922ec5777fec5'
+rev = "acd97f49be1f691c35f567dd79f7391ce9554a9f"
 default-features=false
 features = ["no_oom", "no_panic_handler", "debug"]
 

--- a/substratee-node-calls/Cargo.toml
+++ b/substratee-node-calls/Cargo.toml
@@ -15,10 +15,10 @@ git = "https://github.com/scs/substrate-api-client"
 rev = 'a1e82a08418dc5de0b6bd3bf016bcee004736441'
 
 [dependencies.primitives]
-git = "https://github.com/paritytech/substrate"
+git = "https://github.com/scs/substrate"
 rev = "f17d023bbe179f15678ac9989f471c9b18917e17"
 package = "substrate-primitives"
 
 [dependencies.srml-support]
-git = "https://github.com/paritytech/substrate"
+git = "https://github.com/scs/substrate"
 rev = "f17d023bbe179f15678ac9989f471c9b18917e17"

--- a/worker/Cargo.toml
+++ b/worker/Cargo.toml
@@ -47,35 +47,36 @@ path = "worker-api"
 
 [dependencies.my_node_runtime]
 git = "https://github.com/scs/substraTEE-node"
+rev = "acd97f49be1f691c35f567dd79f7391ce9554a9f"
 package = "substratee-node-runtime"
 default-features = false
 features = ["no_global_allocator"]
 
 [dependencies.runtime_primitives]
-git = 'https://github.com/paritytech/substrate'
+git = 'https://github.com/scs/substrate'
 rev = "f17d023bbe179f15678ac9989f471c9b18917e17"
 package = "sr-primitives"
 
 [dependencies.balances]
-git = "https://github.com/paritytech/substrate"
+git = "https://github.com/scs/substrate"
 rev = "f17d023bbe179f15678ac9989f471c9b18917e17"
 package = "srml-balances"
 
 [dependencies.node-primitives]
-git = "https://github.com/paritytech/substrate"
+git = "https://github.com/scs/substrate"
 rev = "f17d023bbe179f15678ac9989f471c9b18917e17"
 
 [dependencies.primitives]
-git = "https://github.com/paritytech/substrate"
+git = "https://github.com/scs/substrate"
 rev = "f17d023bbe179f15678ac9989f471c9b18917e17"
 package = "substrate-primitives"
 
 [dependencies.substrate-keyring]
-git = "https://github.com/paritytech/substrate"
+git = "https://github.com/scs/substrate"
 rev = "f17d023bbe179f15678ac9989f471c9b18917e17"
 
 [dependencies.system]
-git = "https://github.com/paritytech/substrate"
+git = "https://github.com/scs/substrate"
 rev = "f17d023bbe179f15678ac9989f471c9b18917e17"
 package = "srml-system"
 

--- a/worker/worker-api/Cargo.toml
+++ b/worker/worker-api/Cargo.toml
@@ -13,7 +13,7 @@ sgx_crypto_helper = { rev = "v1.0.9", git = "https://github.com/baidu/rust-sgx-s
 codec = { package = "parity-scale-codec", version = "1.0.0", default-features = false, features = ["derive"] }
 
 [dependencies.primitives]
-git = "https://github.com/paritytech/substrate"
+git = "https://github.com/scs/substrate"
 rev = "f17d023bbe179f15678ac9989f471c9b18917e17"
 package = "substrate-primitives"
 


### PR DESCRIPTION
* we now depend on scs/substrate@f17d023bbe179f15678ac9989f471c9b18917e17 (upstream commit)
* patched primitives and application_crypto are drawn from scs/substrate@substraTEE-M5.1