### PR TITLE
Add support for Intel commercial license

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,7 +41,9 @@ lib/libenclave.a
 bin/client.crt
 bin/client.key
 bin/spid.txt
+bin/spid_production.txt
 bin/key.txt
+bin/key_production.txt
 bin/attestation_report.json
 
 # in order to have 2 workers run and exchange keys

--- a/README.md
+++ b/README.md
@@ -3,15 +3,30 @@ SubstraTEE worker for SubstraTEE node
 
 This is part of [substraTEE](https://github.com/scs/substraTEE)
 
-**Supports Rust nightly-2019-07-15**
- 
-**Enclave is compiled with nightly-2019-10-03**
+**Supports Rust nightly-2019-11-17**
+
+## Intel SGX develoment and production (commercial) license
+In order to perform a remote attestation of the enclave, an [Intel SGX Attestation Enhanced Service Privacy ID (EPID)](https://api.portal.trustedservices.intel.com/EPID-attestation) is needed. We use unlinkable quotes in our code.
+
+### Development Access
+Copy your SPID and key to the following files (use Linux line endings):
+* `bin/spid.txt`: SPID of your subscription
+* `bin/key.txt`: Key of your subscription (primary or secondary works)
+
+The enclave will be signed with the development key found under `enclave/Enclave_privat.pem` and uses the configuration found under `enclave/Enclave.config.xml`.
+
+### Production Access
+Copy your SPID and key to the following files (use Linux line endings):
+* `bin/spid_production.txt`: SPID of your subscription
+* `bin/key_production.txt`: Key of your subscription (primary or secondary works)
+
+The enclave will be signed with the your private key that waa also registered and whitelisted at Intel's. Make sure that the key is exported as an environment variable called `SGX_COMMERCIAL_KEY`. The enclave uses the configuration found under `enclave/Enclave.config.production.xml`.
 
 ## Private-tx demo
 To run a demo for private tokens do the following:
 
-Assumptions: 
-* your machine has SGX support 
+Assumptions:
+* your machine has SGX support
 * Intel SGX SDK installed.
 * rust toolchain is ready to build substrate
 

--- a/enclave/Cargo.toml
+++ b/enclave/Cargo.toml
@@ -14,6 +14,7 @@ crate-type = ["staticlib"]
 
 [features]
 default = []
+production = []
 
 [target.'cfg(not(target_env = "sgx"))'.dependencies]
 sgx_tse       = { rev = "v1.1.0", git = "https://github.com/baidu/rust-sgx-sdk" }

--- a/enclave/Enclave.config.production.xml
+++ b/enclave/Enclave.config.production.xml
@@ -1,0 +1,12 @@
+<!-- Please refer to User's Guide for the explanation of each field -->
+<EnclaveConfiguration>
+  <ProdID>0</ProdID>
+  <ISVSVN>0</ISVSVN>
+  <StackMaxSize>0x40000</StackMaxSize>
+  <HeapMaxSize>0x20000000</HeapMaxSize>
+  <TCSNum>4</TCSNum>
+  <TCSPolicy>0</TCSPolicy> <!-- 0 = Thread Control Structure (TCS) is bound to the untrusted thread -->
+  <DisableDebug>1</DisableDebug>
+  <MiscSelect>0</MiscSelect>
+  <MiscMask>0xFFFFFFFF</MiscMask>
+</EnclaveConfiguration>

--- a/enclave/src/attestation.rs
+++ b/enclave/src/attestation.rs
@@ -53,9 +53,16 @@ use crate::{cert, hex};
 use crate::constants::{RA_SPID, RA_API_KEY, SUBSRATEE_REGISTRY_MODULE, REGISTER_ENCLAVE, RUNTIME_SPEC_VERSION};
 use crate::utils::{hash_from_slice, get_ecc_seed};
 
-//pub const PROD_HOSTNAME:&str = "as.sgx.trustedservices.intel.com";
 pub const DEV_HOSTNAME		: &str = "api.trustedservices.intel.com";
+
+#[cfg(feature = "production")]
+pub const SIGRL_SUFFIX		: &str = "/sgx/attestation/v3/sigrl/";
+#[cfg(feature = "production")]
+pub const REPORT_SUFFIX		: &str = "/sgx/attestation/v3/report";
+
+#[cfg(not(feature = "production"))]
 pub const SIGRL_SUFFIX		: &str = "/sgx/dev/attestation/v3/sigrl/";
+#[cfg(not(feature = "production"))]
 pub const REPORT_SUFFIX		: &str = "/sgx/dev/attestation/v3/report";
 
 extern "C" {

--- a/enclave/src/constants.rs
+++ b/enclave/src/constants.rs
@@ -20,7 +20,14 @@ pub const SEALED_SIGNER_SEED_FILE: 	&str = "ed25519_key_sealed.bin";
 pub const ENCRYPTED_STATE_FILE:		&str = "sealed_stf_state.bin";
 pub const AES_KEY_FILE_AND_INIT_V: 	&str = "aes_key_sealed.bin";
 
+#[cfg(feature = "production")]
+pub static RA_SPID:       &str = "../bin/spid_production.txt";
+#[cfg(feature = "production")]
+pub static RA_API_KEY:	  &str = "../bin/key_production.txt";
+
+#[cfg(not(feature = "production"))]
 pub static RA_SPID:       &str = "../bin/spid.txt";
+#[cfg(not(feature = "production"))]
 pub static RA_API_KEY:	  &str = "../bin/key.txt";
 
 pub static SUBSRATEE_REGISTRY_MODULE: u8 = 6u8;

--- a/worker/Cargo.toml
+++ b/worker/Cargo.toml
@@ -87,6 +87,7 @@ default-features = false
 
 [features]
 default = ["std"]
+production = ["std"]
 std = [
 	"primitives/std",
 	"codec/std",

--- a/worker/src/constants.rs
+++ b/worker/src/constants.rs
@@ -20,5 +20,12 @@ pub static ENCLAVE_FILE:		&str = "../bin/enclave.signed.so";
 pub static RSA_PUB_KEY:			&str = "rsa_pubkey.txt";
 pub static ECC_PUB_KEY:			&str = "ecc_pubkey.txt";
 
-pub static RA_SPID:				&str = "../bin/spid.txt";
-pub static RA_API_KEY:			&str = "../bin/key.txt";
+#[cfg(feature = "production")]
+pub static RA_SPID:       &str = "../bin/spid_production.txt";
+#[cfg(feature = "production")]
+pub static RA_API_KEY:	  &str = "../bin/key_production.txt";
+
+#[cfg(not(feature = "production"))]
+pub static RA_SPID:       &str = "../bin/spid.txt";
+#[cfg(not(feature = "production"))]
+pub static RA_API_KEY:	  &str = "../bin/key.txt";

--- a/worker/src/enclave/init.rs
+++ b/worker/src/enclave/init.rs
@@ -80,7 +80,11 @@ pub fn init_enclave() -> SgxResult<SgxEnclave> {
 
     // Step 2: call sgx_create_enclave to initialize an enclave instance
     // Debug Support: 1 = debug mode, 0 = not debug mode
+    #[cfg(not(feature = "production"))]
     let debug = 1;
+    #[cfg(feature = "production")]
+    let debug = 0;
+
     let mut misc_attr = sgx_misc_attribute_t {
         secs_attr: sgx_attributes_t { flags: 0, xfrm: 0 },
         misc_select: 0,

--- a/worker/src/main.rs
+++ b/worker/src/main.rs
@@ -112,7 +112,12 @@ fn worker(node_url: &str, w_ip: &str, w_port: &str, mu_ra_port: &str) {
 
 	// ------------------------------------------------------------------------
 	// initialize the enclave
-	println!("*** Starting enclave");
+	#[cfg(feature = "production")]
+	println!("*** Starting enclave in production mode");
+	#[cfg(not(feature = "production"))]
+	println!("*** Starting enclave in development mode");
+
+
 	let enclave = match init_enclave() {
 		Ok(r) => {
 			println!("[+] Init Enclave Successful. EID = {}!\n", r.geteid());


### PR DESCRIPTION
Default make target is still development. Production mode can be enabled with `SGX_PRODUCTION=1 make`