### PR TITLE
Cl cleanup enclave

### DIFF
--- a/enclave/Cargo.toml
+++ b/enclave/Cargo.toml
@@ -118,6 +118,8 @@ path = "../stf"
 default-features = false
 features = ["sgx"]
 
+[dependencies.sgx-externalities]
+path = "../substrate-sgx/externalities"
 
 [patch."https://github.com/paritytech/substrate"]
 sr-io = { path = "../substrate-sgx/sr-io", default-features = false, features = ["disable_oom", "disable_panic_handler", "disable_allocator", "sgx"]}

--- a/enclave/src/aes.rs
+++ b/enclave/src/aes.rs
@@ -1,3 +1,20 @@
+/*
+	Copyright 2019 Supercomputing Systems AG
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+		http://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+
+*/
+
 use std::vec::Vec;
 
 use sgx_rand::{Rng, StdRng};

--- a/enclave/src/aes.rs
+++ b/enclave/src/aes.rs
@@ -8,7 +8,7 @@ use ofb::Ofb;
 use ofb::stream_cipher::{NewStreamCipher, SyncStreamCipher};
 
 use crate::constants::AES_KEY_FILE_AND_INIT_V;
-use crate::utils::*;
+use crate::io;
 
 type AesOfb = Ofb<Aes128>;
 
@@ -23,14 +23,14 @@ pub fn read_or_create_sealed() -> SgxResult<(Vec<u8>, Vec<u8>)> {
 }
 
 pub fn read_sealed() -> SgxResult<(Vec<u8>, Vec<u8>)> {
-	let key_iv = read_file(AES_KEY_FILE_AND_INIT_V)?;
+	let key_iv = io::read_file(AES_KEY_FILE_AND_INIT_V)?;
 	Ok((key_iv[..16].to_vec(), key_iv[16..].to_vec()))
 }
 
 pub fn seal(key: [u8; 16], iv: [u8; 16]) -> SgxResult<sgx_status_t>{
 	let mut key_iv = key.to_vec();
 	key_iv.extend_from_slice(&iv);
-	write_file(&key_iv, AES_KEY_FILE_AND_INIT_V)
+	io::write_file(&key_iv, AES_KEY_FILE_AND_INIT_V)
 }
 
 pub fn create_sealed() -> SgxResult<sgx_status_t> {
@@ -42,7 +42,7 @@ pub fn create_sealed() -> SgxResult<sgx_status_t> {
 	};
 
 	rand.fill_bytes(&mut key_iv);
-	write_file(&key_iv, AES_KEY_FILE_AND_INIT_V)
+	io::write_file(&key_iv, AES_KEY_FILE_AND_INIT_V)
 }
 
 /// If AES acts on the encrypted data it decrypts and vice versa

--- a/enclave/src/aes.rs
+++ b/enclave/src/aes.rs
@@ -1,0 +1,53 @@
+use std::vec::Vec;
+
+use sgx_rand::{Rng, StdRng};
+use sgx_types::*;
+
+use aes::Aes128;
+use ofb::Ofb;
+use ofb::stream_cipher::{NewStreamCipher, SyncStreamCipher};
+
+use crate::constants::AES_KEY_FILE_AND_INIT_V;
+use crate::utils::*;
+
+type AesOfb = Ofb<Aes128>;
+
+pub fn read_or_create_aes_key_iv() -> SgxResult<(Vec<u8>, Vec<u8>)> {
+	match read_aes_key_and_iv() {
+		Ok((k,i)) => Ok((k, i)),
+		Err(_) => {
+			create_sealed_aes_key_and_iv()?;
+			read_aes_key_and_iv()
+		},
+	}
+}
+
+pub fn read_aes_key_and_iv() -> SgxResult<(Vec<u8>, Vec<u8>)> {
+	let key_iv = read_file(AES_KEY_FILE_AND_INIT_V)?;
+	Ok((key_iv[..16].to_vec(), key_iv[16..].to_vec()))
+}
+
+pub fn store_aes_key_and_iv(key: [u8; 16], iv: [u8; 16]) -> SgxResult<sgx_status_t>{
+	let mut key_iv = key.to_vec();
+	key_iv.extend_from_slice(&iv);
+	write_file(&key_iv, AES_KEY_FILE_AND_INIT_V)
+}
+
+pub fn create_sealed_aes_key_and_iv() -> SgxResult<sgx_status_t> {
+	let mut key_iv = [0u8; 32];
+
+	let mut rand = match StdRng::new() {
+		Ok(rng) => rng,
+		Err(_) => { return Err(sgx_status_t::SGX_ERROR_UNEXPECTED); },
+	};
+
+	rand.fill_bytes(&mut key_iv);
+	write_file(&key_iv, AES_KEY_FILE_AND_INIT_V)
+}
+
+/// If AES acts on the encrypted data it decrypts and vice versa
+pub fn aes_de_or_encrypt(bytes: &mut Vec<u8>) -> SgxResult<sgx_status_t> {
+	let (key, iv) = read_or_create_aes_key_iv()?;
+	AesOfb::new_var(&key, &iv).unwrap().apply_keystream(bytes);
+	Ok(sgx_status_t::SGX_SUCCESS)
+}

--- a/enclave/src/attestation.rs
+++ b/enclave/src/attestation.rs
@@ -51,7 +51,8 @@ use substrate_api_client::compose_extrinsic_offline;
 
 use crate::{cert, hex};
 use crate::constants::{RA_SPID, RA_API_KEY, SUBSRATEE_REGISTRY_MODULE, REGISTER_ENCLAVE, RUNTIME_SPEC_VERSION};
-use crate::utils::{hash_from_slice, get_ecc_seed};
+use crate::utils::hash_from_slice;
+use crate::ed25519::get_ecc_seed;
 
 pub const DEV_HOSTNAME		: &str = "api.trustedservices.intel.com";
 

--- a/enclave/src/attestation.rs
+++ b/enclave/src/attestation.rs
@@ -51,7 +51,7 @@ use substrate_api_client::compose_extrinsic_offline;
 
 use crate::{cert, hex};
 use crate::constants::{RA_SPID, RA_API_KEY, SUBSRATEE_REGISTRY_MODULE, REGISTER_ENCLAVE, RUNTIME_SPEC_VERSION};
-use crate::utils::hash_from_slice;
+use crate::utils::{hash_from_slice, write_slice_and_whitespace_pad};
 use crate::ed25519;
 
 pub const DEV_HOSTNAME		: &str = "api.trustedservices.intel.com";
@@ -614,11 +614,7 @@ pub unsafe extern "C" fn perform_ra(
 	let encoded = xt.encode();
 	debug!("    [Enclave] Encoded extrinsic = {:?}", encoded);
 
-	// split the extrinsic_slice at the length of the encoded extrinsic
-	// and fill the right side with whitespace
-	let (left, right) = extrinsic_slice.split_at_mut(encoded.len());
-	left.clone_from_slice(&encoded);
-	right.iter_mut().for_each(|x| *x = 0x20);
+	write_slice_and_whitespace_pad(extrinsic_slice, encoded);
 
 	sgx_status_t::SGX_SUCCESS
 }

--- a/enclave/src/ed25519.rs
+++ b/enclave/src/ed25519.rs
@@ -1,3 +1,20 @@
+/*
+	Copyright 2019 Supercomputing Systems AG
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+		http://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+
+*/
+
 use std::sgxfs::SgxFile;
 use std::vec::Vec;
 

--- a/enclave/src/ed25519.rs
+++ b/enclave/src/ed25519.rs
@@ -10,29 +10,29 @@ use log::*;
 use crate::utils::*;
 use crate::constants::SEALED_SIGNER_SEED_FILE;
 
-pub fn get_sealed_ecc_pair() ->  SgxResult<ed25519::Pair> {
-	let seedvec = get_ecc_seed()?;
+pub fn unseal_pair() ->  SgxResult<ed25519::Pair> {
+	let seedvec = unseal()?;
 
 	let mut seed = [0u8; 32];
 	let seedvec = &seedvec[..seed.len()];
-// panics if not enough data
+	// panics if not enough data
 	seed.copy_from_slice(seedvec);
 	Ok(ed25519::Pair::from_seed(&seed))
 }
 
-pub fn create_sealed_ed25519_seed_if_not_existent() -> SgxResult<sgx_status_t> {
+pub fn create_sealed_if_absent() -> SgxResult<sgx_status_t> {
 	if SgxFile::open(SEALED_SIGNER_SEED_FILE).is_err() {
 		info ! ("[Enclave] Keyfile not found, creating new! {}", SEALED_SIGNER_SEED_FILE);
-		return create_sealed_ed25519_seed()
+		return create_sealed_seed()
 	}
 	Ok(sgx_status_t::SGX_SUCCESS)
 }
 
-pub fn get_ecc_seed() -> SgxResult<Vec<u8>> {
+fn unseal() -> SgxResult<Vec<u8>> {
 	read_file(SEALED_SIGNER_SEED_FILE)
 }
 
-pub fn create_sealed_ed25519_seed() -> SgxResult<sgx_status_t> {
+pub fn create_sealed_seed() -> SgxResult<sgx_status_t> {
 	let mut seed = [0u8; 32];
 	let mut rand = match StdRng::new() {
 		Ok(rng) => rng,

--- a/enclave/src/ed25519.rs
+++ b/enclave/src/ed25519.rs
@@ -7,11 +7,11 @@ use sgx_rand::{Rng, StdRng};
 use primitives::{ed25519, crypto::Pair};
 use log::*;
 
-use crate::utils::*;
+use crate::io;
 use crate::constants::SEALED_SIGNER_SEED_FILE;
 
 pub fn unseal_pair() ->  SgxResult<ed25519::Pair> {
-	let seedvec = unseal()?;
+	let seedvec = unseal_seed()?;
 
 	let mut seed = [0u8; 32];
 	let seedvec = &seedvec[..seed.len()];
@@ -28,8 +28,12 @@ pub fn create_sealed_if_absent() -> SgxResult<sgx_status_t> {
 	Ok(sgx_status_t::SGX_SUCCESS)
 }
 
-fn unseal() -> SgxResult<Vec<u8>> {
-	read_file(SEALED_SIGNER_SEED_FILE)
+fn unseal_seed() -> SgxResult<Vec<u8>> {
+	io::read_file(SEALED_SIGNER_SEED_FILE)
+}
+
+pub fn seal_seed(pair: &[u8]) -> SgxResult<sgx_status_t> {
+	io::write_file(pair, SEALED_SIGNER_SEED_FILE)
 }
 
 pub fn create_sealed_seed() -> SgxResult<sgx_status_t> {
@@ -40,5 +44,5 @@ pub fn create_sealed_seed() -> SgxResult<sgx_status_t> {
 	};
 	rand.fill_bytes(&mut seed);
 
-	write_file(&seed, SEALED_SIGNER_SEED_FILE)
+	seal_seed(&seed)
 }

--- a/enclave/src/ed25519.rs
+++ b/enclave/src/ed25519.rs
@@ -1,0 +1,44 @@
+use std::sgxfs::SgxFile;
+use std::vec::Vec;
+
+use sgx_types::*;
+use sgx_rand::{Rng, StdRng};
+
+use primitives::{ed25519, crypto::Pair};
+use log::*;
+
+use crate::utils::*;
+use crate::constants::SEALED_SIGNER_SEED_FILE;
+
+pub fn get_sealed_ecc_pair() ->  SgxResult<ed25519::Pair> {
+	let seedvec = get_ecc_seed()?;
+
+	let mut seed = [0u8; 32];
+	let seedvec = &seedvec[..seed.len()];
+// panics if not enough data
+	seed.copy_from_slice(seedvec);
+	Ok(ed25519::Pair::from_seed(&seed))
+}
+
+pub fn create_sealed_ed25519_seed_if_not_existent() -> SgxResult<sgx_status_t> {
+	if SgxFile::open(SEALED_SIGNER_SEED_FILE).is_err() {
+		info ! ("[Enclave] Keyfile not found, creating new! {}", SEALED_SIGNER_SEED_FILE);
+		return create_sealed_ed25519_seed()
+	}
+	Ok(sgx_status_t::SGX_SUCCESS)
+}
+
+pub fn get_ecc_seed() -> SgxResult<Vec<u8>> {
+	read_file(SEALED_SIGNER_SEED_FILE)
+}
+
+pub fn create_sealed_ed25519_seed() -> SgxResult<sgx_status_t> {
+	let mut seed = [0u8; 32];
+	let mut rand = match StdRng::new() {
+		Ok(rng) => rng,
+		Err(_) => { return Err(sgx_status_t::SGX_ERROR_UNEXPECTED); },
+	};
+	rand.fill_bytes(&mut seed);
+
+	write_file(&seed, SEALED_SIGNER_SEED_FILE)
+}

--- a/enclave/src/io.rs
+++ b/enclave/src/io.rs
@@ -1,0 +1,102 @@
+/*
+	Copyright 2019 Supercomputing Systems AG
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+		http://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+
+*/
+use std::fs::File;
+use std::io::{Read, Write};
+use std::sgxfs::SgxFile;
+use std::vec::Vec;
+
+use sgx_types::*;
+
+use log::*;
+
+pub fn write_file(bytes: &[u8], filepath: &str) -> SgxResult<sgx_status_t> {
+	match SgxFile::create(filepath) {
+		Ok(mut f) => match f.write_all(bytes) {
+			Ok(()) => {
+				info!("[Enclave] Writing keyfile '{}' successful", filepath);
+				Ok(sgx_status_t::SGX_SUCCESS)
+			}
+			Err(x) => {
+				error!("[Enclave -] Writing keyfile '{}' failed! Err: {}", filepath, x);
+				Err(sgx_status_t::SGX_ERROR_UNEXPECTED)
+			}
+		},
+		Err(x) => {
+			error!("[Enclave !] Creating keyfile '{}' Err: {}", filepath, x);
+			Err(sgx_status_t::SGX_ERROR_UNEXPECTED)
+		}
+	}
+}
+
+pub fn read_file(filepath: &str) -> SgxResult<Vec<u8>> {
+	let mut keyvec: Vec<u8> = Vec::new();
+	match SgxFile::open(filepath) {
+		Ok(mut f) => match f.read_to_end(&mut keyvec) {
+			Ok(len) => {
+				info!("[Enclave] Read {} bytes from key file", len);
+				Ok(keyvec)
+			}
+			Err(x) => {
+				error!("[Enclave] Read sealed file failed {}: Err {}", filepath, x);
+				Err(sgx_status_t::SGX_ERROR_UNEXPECTED)
+			}
+		},
+		Err(x) => {
+			info!("[Enclave] Can't find sealed file {} Err: {}" , filepath, x);
+			Err(sgx_status_t::SGX_ERROR_UNEXPECTED)
+		}
+	}
+}
+
+pub fn read_plaintext(filepath: &str) -> SgxResult<Vec<u8>> {
+	let mut state_vec: Vec<u8> = Vec::new();
+	match File::open(filepath) {
+		Ok(mut f) => match f.read_to_end(&mut state_vec) {
+			Ok(len) => {
+				info!("[Enclave] Read {} bytes from state file", len);
+				Ok(state_vec)
+			}
+			Err(x) => {
+				error!("[Enclave] Read encrypted state file failed {}", x);
+				Err(sgx_status_t::SGX_ERROR_UNEXPECTED)
+			}
+		},
+		Err(x) => {
+			info!("[Enclave] No encrypted state file found! {} Err: {}", filepath, x);
+			Ok(state_vec)
+		}
+	}
+}
+
+pub fn write_plaintext(bytes: &[u8], filepath: &str) -> SgxResult<sgx_status_t> {
+	match File::create(filepath) {
+		Ok(mut f) => match f.write_all(bytes) {
+			Ok(()) => {
+				info!("[Enclave] Writing to file '{}' successful", filepath);
+				Ok(sgx_status_t::SGX_SUCCESS)
+			}
+			Err(x) => {
+				error!("[Enclave] Writing to '{}' failed! {}", filepath, x);
+				Err(sgx_status_t::SGX_ERROR_UNEXPECTED)
+			}
+		},
+		Err(x) => {
+			error!("[Enclave] Creating file '{}' error! {}", filepath, x);
+			Err(sgx_status_t::SGX_ERROR_UNEXPECTED)
+		}
+	}
+}

--- a/enclave/src/lib.rs
+++ b/enclave/src/lib.rs
@@ -111,12 +111,7 @@ pub unsafe extern "C" fn get_rsa_encryption_pubkey(pubkey: *mut u8, pubkey_size:
 	};
 
 	let pubkey_slice = slice::from_raw_parts_mut(pubkey, pubkey_size as usize);
-
-	// split the pubkey_slice at the length of the rsa_pubkey_json
-	// and fill the right side with whitespace so that the json can be decoded later on
-	let (left, right) = pubkey_slice.split_at_mut(rsa_pubkey_json.len());
-	left.clone_from_slice(rsa_pubkey_json.as_bytes());
-	right.iter_mut().for_each(|x| *x = 0x20);
+	write_slice_and_whitespace_pad(pubkey_slice, rsa_pubkey_json.as_bytes().to_vec());
 
 	sgx_status_t::SGX_SUCCESS
 }
@@ -227,11 +222,7 @@ pub unsafe extern "C" fn execute_stf(
 
 	let encoded = xt.encode();
 
-	// split the extrinsic_slice at the length of the encoded extrinsic
-	// and fill the right side with whitespace
-	let (left, right) = extrinsic_slice.split_at_mut(encoded.len());
-	left.clone_from_slice(&encoded);
-	right.iter_mut().for_each(|x| *x = 0x20);
+	write_slice_and_whitespace_pad(extrinsic_slice, encoded);
 
 	sgx_status_t::SGX_SUCCESS
 }
@@ -267,14 +258,10 @@ pub unsafe extern "C" fn get_state(
 		None => vec!(0),
 	};
 
-	// split the extrinsic_slice at the length of the encoded extrinsic
-	// and fill the right side with whitespace
-	let (left, right) = value_slice.split_at_mut(value_vec.len());
-	left.clone_from_slice(&value_vec);
-	//FIXME: now implicitly assuming we pass unsigned integer vecs, not strings terminated by 0x20
-	//FIXME: we should really pass an Option<Vec<u8>>
-	right.iter_mut().for_each(|x| *x = 0x00);
-	//right.iter_mut().for_each(|x| *x = 0x20);
+//	//FIXME: now implicitly assuming we pass unsigned integer vecs, not strings terminated by 0x20
+//	//FIXME: we should really pass an Option<Vec<u8>>
+	write_slice_and_whitespace_pad(value_slice, value_vec);
+
 	sgx_status_t::SGX_SUCCESS
 }
 

--- a/enclave/src/lib.rs
+++ b/enclave/src/lib.rs
@@ -54,7 +54,7 @@ use std::slice;
 use std::string::String;
 use std::vec::Vec;
 
-use utils::*;
+use utils::{hash_from_slice, write_slice_and_whitespace_pad};
 
 mod constants;
 mod utils;
@@ -63,6 +63,7 @@ mod rsa3072;
 mod ed25519;
 mod state;
 mod aes;
+mod io;
 
 pub mod cert;
 pub mod hex;
@@ -192,7 +193,7 @@ pub unsafe extern "C" fn execute_stf(
 	let state_hash = rsgx_sha256_slice(&enc_state).unwrap();
 	debug!("    [Enclave] Updated encrypted state. hash=0x{}", hex::encode_hex(&state_hash));
 
-	if let Err(status) = write_plaintext(&enc_state, ENCRYPTED_STATE_FILE) {
+	if let Err(status) = io::write_plaintext(&enc_state, ENCRYPTED_STATE_FILE) {
 		return status
 	}
 

--- a/enclave/src/lib.rs
+++ b/enclave/src/lib.rs
@@ -190,7 +190,6 @@ pub unsafe extern "C" fn execute_stf(
 
 
 	let state_hash = rsgx_sha256_slice(&enc_state).unwrap();
-
 	debug!("    [Enclave] Updated encrypted state. hash=0x{}", hex::encode_hex(&state_hash));
 
 	if let Err(status) = write_plaintext(&enc_state, ENCRYPTED_STATE_FILE) {
@@ -221,7 +220,6 @@ pub unsafe extern "C" fn execute_stf(
     );
 
 	let encoded = xt.encode();
-
 	write_slice_and_whitespace_pad(extrinsic_slice, encoded);
 
 	sgx_status_t::SGX_SUCCESS

--- a/enclave/src/lib.rs
+++ b/enclave/src/lib.rs
@@ -55,10 +55,18 @@ use std::string::String;
 use std::vec::Vec;
 
 use utils::*;
+use rsa3072::*;
+use ed25519::*;
+use state::*;
+use crate::aes::*;
 
 mod constants;
 mod utils;
 mod attestation;
+mod rsa3072;
+mod ed25519;
+mod state;
+mod aes;
 
 pub mod cert;
 pub mod hex;

--- a/enclave/src/rsa3072.rs
+++ b/enclave/src/rsa3072.rs
@@ -1,3 +1,20 @@
+/*
+	Copyright 2019 Supercomputing Systems AG
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+		http://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+
+*/
+
 use std::sgxfs::SgxFile;
 use std::vec::Vec;
 

--- a/enclave/src/rsa3072.rs
+++ b/enclave/src/rsa3072.rs
@@ -7,11 +7,11 @@ use sgx_types::*;
 
 use log::*;
 
-use crate::utils::*;
+use crate::io;
 use crate::constants::RSA3072_SEALED_KEY_FILE;
 
 pub fn unseal_pair() -> SgxResult<Rsa3072KeyPair> {
-	let keyvec = read_file(RSA3072_SEALED_KEY_FILE)?;
+	let keyvec = io::read_file(RSA3072_SEALED_KEY_FILE)?;
 	let key_json_str = std::str::from_utf8(&keyvec).unwrap();
 	let pair: Rsa3072KeyPair = serde_json::from_str(&key_json_str).unwrap();
 	Ok(pair)
@@ -36,11 +36,11 @@ pub fn create_sealed() -> Result<sgx_status_t, sgx_status_t> {
 	let rsa_keypair = Rsa3072KeyPair::new().unwrap();
 	let rsa_key_json = serde_json::to_string(&rsa_keypair).unwrap();
 	// println!("[Enclave] generated RSA3072 key pair. Cleartext: {}", rsa_key_json);
-	write_file(rsa_key_json.as_bytes(), RSA3072_SEALED_KEY_FILE)
+	seal(rsa_key_json.as_bytes())
 }
 
 pub fn seal(pair: &[u8]) -> SgxResult<sgx_status_t> {
-	write_file(pair, RSA3072_SEALED_KEY_FILE)
+	io::write_file(pair, RSA3072_SEALED_KEY_FILE)
 }
 
 pub fn decrypt(ciphertext_slice: &[u8], rsa_pair: &Rsa3072KeyPair) -> Vec<u8> {

--- a/enclave/src/rsa3072.rs
+++ b/enclave/src/rsa3072.rs
@@ -10,40 +10,40 @@ use log::*;
 use crate::utils::*;
 use crate::constants::RSA3072_SEALED_KEY_FILE;
 
-pub fn read_rsa_keypair() -> SgxResult<Rsa3072KeyPair> {
+pub fn unseal_pair() -> SgxResult<Rsa3072KeyPair> {
 	let keyvec = read_file(RSA3072_SEALED_KEY_FILE)?;
 	let key_json_str = std::str::from_utf8(&keyvec).unwrap();
 	let pair: Rsa3072KeyPair = serde_json::from_str(&key_json_str).unwrap();
 	Ok(pair)
 }
 
-pub fn read_rsa_pubkey() -> SgxResult<Rsa3072PubKey> {
-	let pair = (read_rsa_keypair())?;
+pub fn unseal_pubkey() -> SgxResult<Rsa3072PubKey> {
+	let pair = (unseal_pair())?;
 	let pubkey = pair.export_pubkey().unwrap();
 
 	Ok(pubkey)
 }
 
-pub fn create_sealed_rsa3072_keypair_if_not_existent() -> SgxResult<sgx_status_t> {
+pub fn create_sealed_if_absent() -> SgxResult<sgx_status_t> {
 	if SgxFile::open(RSA3072_SEALED_KEY_FILE).is_err() {
 		info ! ("[Enclave] Keyfile not found, creating new! {}", RSA3072_SEALED_KEY_FILE);
-		return create_sealed_rsa3072_keypair()
+		return create_sealed()
 	}
 	Ok(sgx_status_t::SGX_SUCCESS)
 }
 
-pub fn create_sealed_rsa3072_keypair() -> Result<sgx_status_t, sgx_status_t> {
+pub fn create_sealed() -> Result<sgx_status_t, sgx_status_t> {
 	let rsa_keypair = Rsa3072KeyPair::new().unwrap();
 	let rsa_key_json = serde_json::to_string(&rsa_keypair).unwrap();
 	// println!("[Enclave] generated RSA3072 key pair. Cleartext: {}", rsa_key_json);
 	write_file(rsa_key_json.as_bytes(), RSA3072_SEALED_KEY_FILE)
 }
 
-pub fn store_rsa_key_pair(pair: &[u8]) -> SgxResult<sgx_status_t> {
+pub fn seal(pair: &[u8]) -> SgxResult<sgx_status_t> {
 	write_file(pair, RSA3072_SEALED_KEY_FILE)
 }
 
-pub fn decrypt_payload(ciphertext_slice: &[u8], rsa_pair: &Rsa3072KeyPair) -> Vec<u8> {
+pub fn decrypt(ciphertext_slice: &[u8], rsa_pair: &Rsa3072KeyPair) -> Vec<u8> {
 	let mut decrypted_buffer = Vec::new();
 	rsa_pair.decrypt_buffer(ciphertext_slice, &mut decrypted_buffer).unwrap();
 	decrypted_buffer

--- a/enclave/src/rsa3072.rs
+++ b/enclave/src/rsa3072.rs
@@ -1,0 +1,50 @@
+use std::sgxfs::SgxFile;
+use std::vec::Vec;
+
+use sgx_crypto_helper::rsa3072::{Rsa3072KeyPair, Rsa3072PubKey};
+use sgx_crypto_helper::RsaKeyPair;
+use sgx_types::*;
+
+use log::*;
+
+use crate::utils::*;
+use crate::constants::RSA3072_SEALED_KEY_FILE;
+
+pub fn read_rsa_keypair() -> SgxResult<Rsa3072KeyPair> {
+	let keyvec = read_file(RSA3072_SEALED_KEY_FILE)?;
+	let key_json_str = std::str::from_utf8(&keyvec).unwrap();
+	let pair: Rsa3072KeyPair = serde_json::from_str(&key_json_str).unwrap();
+	Ok(pair)
+}
+
+pub fn read_rsa_pubkey() -> SgxResult<Rsa3072PubKey> {
+	let pair = (read_rsa_keypair())?;
+	let pubkey = pair.export_pubkey().unwrap();
+
+	Ok(pubkey)
+}
+
+pub fn create_sealed_rsa3072_keypair_if_not_existent() -> SgxResult<sgx_status_t> {
+	if SgxFile::open(RSA3072_SEALED_KEY_FILE).is_err() {
+		info ! ("[Enclave] Keyfile not found, creating new! {}", RSA3072_SEALED_KEY_FILE);
+		return create_sealed_rsa3072_keypair()
+	}
+	Ok(sgx_status_t::SGX_SUCCESS)
+}
+
+pub fn create_sealed_rsa3072_keypair() -> Result<sgx_status_t, sgx_status_t> {
+	let rsa_keypair = Rsa3072KeyPair::new().unwrap();
+	let rsa_key_json = serde_json::to_string(&rsa_keypair).unwrap();
+	// println!("[Enclave] generated RSA3072 key pair. Cleartext: {}", rsa_key_json);
+	write_file(rsa_key_json.as_bytes(), RSA3072_SEALED_KEY_FILE)
+}
+
+pub fn store_rsa_key_pair(pair: &[u8]) -> SgxResult<sgx_status_t> {
+	write_file(pair, RSA3072_SEALED_KEY_FILE)
+}
+
+pub fn decrypt_payload(ciphertext_slice: &[u8], rsa_pair: &Rsa3072KeyPair) -> Vec<u8> {
+	let mut decrypted_buffer = Vec::new();
+	rsa_pair.decrypt_buffer(ciphertext_slice, &mut decrypted_buffer).unwrap();
+	decrypted_buffer
+}

--- a/enclave/src/state.rs
+++ b/enclave/src/state.rs
@@ -1,0 +1,45 @@
+use std::vec::Vec;
+
+use sgx_types::*;
+
+use log::*;
+
+use crate::aes::*;
+use crate::utils::*;
+
+pub fn read_state_from_file(path: &str) -> SgxResult<Vec<u8>> {
+	let mut bytes = match read_plaintext(path) {
+		Ok(vec) => match vec.len() {
+			0 => return Ok(vec),
+			_ => vec,
+		},
+		Err(e) => return Err(e),
+	};
+
+	aes_de_or_encrypt(&mut bytes)?;
+	debug!("buffer decrypted = {:?}", bytes);
+
+	Ok(bytes)
+}
+
+pub fn write_state_to_file(bytes: &mut Vec<u8>, path: &str) -> SgxResult<sgx_status_t> {
+	debug!("plaintext data to be written: {:?}", bytes);
+
+	aes_de_or_encrypt(bytes)?;
+
+	write_plaintext(&bytes, path)?;
+	Ok(sgx_status_t::SGX_SUCCESS)
+}
+
+pub fn test_encrypted_state_io_works() {
+	let path = "test_state_file.bin";
+	let plaintext = b"The quick brown fox jumps over the lazy dog.";
+	create_sealed_aes_key_and_iv().unwrap();
+
+	aes_de_or_encrypt(&mut plaintext.to_vec()).unwrap();
+	write_state_to_file(&mut plaintext.to_vec(), path).unwrap();
+	let state: Vec<u8> = read_state_from_file(path).unwrap();
+
+	assert_eq!(state, plaintext.to_vec());
+	std::fs::remove_file(path).unwrap();
+}

--- a/enclave/src/state.rs
+++ b/enclave/src/state.rs
@@ -5,10 +5,10 @@ use sgx_types::*;
 use log::*;
 
 use crate::aes;
-use crate::utils::*;
+use crate::io;
 
 pub fn read(path: &str) -> SgxResult<Vec<u8>> {
-	let mut bytes = match read_plaintext(path) {
+	let mut bytes = match io::read_plaintext(path) {
 		Ok(vec) => match vec.len() {
 			0 => return Ok(vec),
 			_ => vec,
@@ -27,7 +27,7 @@ pub fn write_encrypted(bytes: &mut Vec<u8>, path: &str) -> SgxResult<sgx_status_
 
 	aes::de_or_encrypt(bytes)?;
 
-	write_plaintext(&bytes, path)?;
+	io::write_plaintext(&bytes, path)?;
 	Ok(sgx_status_t::SGX_SUCCESS)
 }
 

--- a/enclave/src/state.rs
+++ b/enclave/src/state.rs
@@ -1,3 +1,20 @@
+/*
+	Copyright 2019 Supercomputing Systems AG
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+		http://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+
+*/
+
 use std::vec::Vec;
 
 use sgx_types::*;

--- a/enclave/src/state.rs
+++ b/enclave/src/state.rs
@@ -1,13 +1,16 @@
 use std::vec::Vec;
 
+use sgx_serialize::SerializeHelper;
 use sgx_types::*;
 
 use log::*;
 
-use crate::aes::*;
+use substratee_stf::State;
+
+use crate::aes;
 use crate::utils::*;
 
-pub fn read_state_from_file(path: &str) -> SgxResult<Vec<u8>> {
+pub fn read(path: &str) -> SgxResult<Vec<u8>> {
 	let mut bytes = match read_plaintext(path) {
 		Ok(vec) => match vec.len() {
 			0 => return Ok(vec),
@@ -16,29 +19,36 @@ pub fn read_state_from_file(path: &str) -> SgxResult<Vec<u8>> {
 		Err(e) => return Err(e),
 	};
 
-	aes_de_or_encrypt(&mut bytes)?;
+	aes::de_or_encrypt(&mut bytes)?;
 	debug!("buffer decrypted = {:?}", bytes);
 
 	Ok(bytes)
 }
 
-pub fn write_state_to_file(bytes: &mut Vec<u8>, path: &str) -> SgxResult<sgx_status_t> {
+pub fn write_encrypted(bytes: &mut Vec<u8>, path: &str) -> SgxResult<sgx_status_t> {
 	debug!("plaintext data to be written: {:?}", bytes);
 
-	aes_de_or_encrypt(bytes)?;
+	aes::de_or_encrypt(bytes)?;
 
 	write_plaintext(&bytes, path)?;
 	Ok(sgx_status_t::SGX_SUCCESS)
 }
 
+pub fn encrypt(value: State) -> Result<Vec<u8>, sgx_status_t> {
+	let helper = SerializeHelper::new();
+	let mut c = helper.encode(value).unwrap();
+	aes::de_or_encrypt(&mut c)?;
+	Ok(c)
+}
+
 pub fn test_encrypted_state_io_works() {
 	let path = "test_state_file.bin";
 	let plaintext = b"The quick brown fox jumps over the lazy dog.";
-	create_sealed_aes_key_and_iv().unwrap();
+	aes::create_sealed().unwrap();
 
-	aes_de_or_encrypt(&mut plaintext.to_vec()).unwrap();
-	write_state_to_file(&mut plaintext.to_vec(), path).unwrap();
-	let state: Vec<u8> = read_state_from_file(path).unwrap();
+	aes::de_or_encrypt(&mut plaintext.to_vec()).unwrap();
+	write_encrypted(&mut plaintext.to_vec(), path).unwrap();
+	let state: Vec<u8> = read(path).unwrap();
 
 	assert_eq!(state, plaintext.to_vec());
 	std::fs::remove_file(path).unwrap();

--- a/enclave/src/state.rs
+++ b/enclave/src/state.rs
@@ -1,11 +1,8 @@
 use std::vec::Vec;
 
-use sgx_serialize::SerializeHelper;
 use sgx_types::*;
 
 use log::*;
-
-use substratee_stf::State;
 
 use crate::aes;
 use crate::utils::*;
@@ -34,11 +31,9 @@ pub fn write_encrypted(bytes: &mut Vec<u8>, path: &str) -> SgxResult<sgx_status_
 	Ok(sgx_status_t::SGX_SUCCESS)
 }
 
-pub fn encrypt(value: State) -> Result<Vec<u8>, sgx_status_t> {
-	let helper = SerializeHelper::new();
-	let mut c = helper.encode(value).unwrap();
-	aes::de_or_encrypt(&mut c)?;
-	Ok(c)
+pub fn encrypt(mut state: Vec<u8>) -> Result<Vec<u8>, sgx_status_t> {
+	aes::de_or_encrypt(&mut state)?;
+	Ok(state)
 }
 
 pub fn test_encrypted_state_io_works() {

--- a/enclave/src/tls_ra.rs
+++ b/enclave/src/tls_ra.rs
@@ -14,7 +14,7 @@ use crate::attestation::create_ra_report_and_signature;
 use crate::constants::ENCRYPTED_STATE_FILE;
 use crate::cert;
 use crate::{ocall_read_ipfs, ocall_write_ipfs};
-use crate::utils::*;
+use crate::io;
 use crate::rsa3072;
 use crate::aes;
 
@@ -128,7 +128,7 @@ pub unsafe extern "C" fn run_server(socket_fd: c_int, sign_type: sgx_quote_sign_
 
 	println!("    [Enclave] (MU-RA-Server) Keys sent, writing state to IPFS (= file hosting service)");
 
-	let enc_state = match read_plaintext(ENCRYPTED_STATE_FILE) {
+	let enc_state = match io::read_plaintext(ENCRYPTED_STATE_FILE) {
 		Ok(state) => state,
 		Err(status) => return status,
 	};
@@ -277,7 +277,7 @@ pub extern "C" fn run_client(socket_fd: c_int, sign_type: sgx_quote_sign_type_t)
 
 
 	println!("    [Enclave] (MU-RA-Client) Got encrypted state from ipfs: {:?}\n", enc_state);
-	if let Err(e) = write_plaintext(&enc_state, ENCRYPTED_STATE_FILE) {
+	if let Err(e) = io::write_plaintext(&enc_state, ENCRYPTED_STATE_FILE) {
 		return e;
 	}
 

--- a/enclave/src/tls_ra.rs
+++ b/enclave/src/tls_ra.rs
@@ -15,6 +15,8 @@ use crate::constants::ENCRYPTED_STATE_FILE;
 use crate::cert;
 use crate::{ocall_read_ipfs, ocall_write_ipfs};
 use crate::utils::*;
+use crate::rsa3072::*;
+use crate::aes::*;
 
 struct ClientAuth {
 	outdated_ok: bool,

--- a/enclave/src/utils.rs
+++ b/enclave/src/utils.rs
@@ -116,24 +116,4 @@ pub fn write_slice_and_whitespace_pad(writable: &mut [u8], data: Vec<u8>) {
 	right.iter_mut().for_each(|x| *x = 0x20);
 }
 
-/*
-pub fn blake2s(plaintext: &[u8]) -> [u8; 32] {
-	let mut call_hash: [u8; 32] = Default::default();
-	Blake2s::blake2s(&mut call_hash, &plaintext[..], &[0; 32]);
-	call_hash
-}
-
-// Same functions as in substrate/core/primitives, but using the no_std blake2_rfc
-/// Do a Blake2 256-bit hash and place result in `dest`.
-fn blake2_256_into(data: &[u8], dest: &mut [u8; 32]) {
-	dest.copy_from_slice(blake2b(32, &[], data).as_bytes());
-}
-
-/// Do a Blake2 256-bit hash and return result.
-pub fn blake2_256(data: &[u8]) -> [u8; 32] {
-	let mut r = [0; 32];
-	blake2_256_into(data, &mut r);
-	r
-}
-*/
 

--- a/enclave/src/utils.rs
+++ b/enclave/src/utils.rs
@@ -14,94 +14,10 @@
 	limitations under the License.
 
 */
-use std::fs::File;
-use std::io::{Read, Write};
-use std::sgxfs::SgxFile;
 use std::vec::Vec;
-
-use sgx_types::*;
-
-use log::*;
 
 use crate::Hash;
 
-pub fn write_file(bytes: &[u8], filepath: &str) -> SgxResult<sgx_status_t> {
-	match SgxFile::create(filepath) {
-		Ok(mut f) => match f.write_all(bytes) {
-			Ok(()) => {
-				info!("[Enclave] Writing keyfile '{}' successful", filepath);
-				Ok(sgx_status_t::SGX_SUCCESS)
-			}
-			Err(x) => {
-				error!("[Enclave -] Writing keyfile '{}' failed! Err: {}", filepath, x);
-				Err(sgx_status_t::SGX_ERROR_UNEXPECTED)
-			}
-		},
-		Err(x) => {
-			error!("[Enclave !] Creating keyfile '{}' Err: {}", filepath, x);
-			Err(sgx_status_t::SGX_ERROR_UNEXPECTED)
-		}
-	}
-}
-
-pub fn read_file(filepath: &str) -> SgxResult<Vec<u8>> {
-	let mut keyvec: Vec<u8> = Vec::new();
-	match SgxFile::open(filepath) {
-		Ok(mut f) => match f.read_to_end(&mut keyvec) {
-			Ok(len) => {
-				info!("[Enclave] Read {} bytes from key file", len);
-				Ok(keyvec)
-			}
-			Err(x) => {
-				error!("[Enclave] Read sealed file failed {}: Err {}", filepath, x);
-				Err(sgx_status_t::SGX_ERROR_UNEXPECTED)
-			}
-		},
-		Err(x) => {
-			info!("[Enclave] Can't find sealed file {} Err: {}" , filepath, x);
-			Err(sgx_status_t::SGX_ERROR_UNEXPECTED)
-		}
-	}
-}
-
-pub fn read_plaintext(filepath: &str) -> SgxResult<Vec<u8>> {
-	let mut state_vec: Vec<u8> = Vec::new();
-	match File::open(filepath) {
-		Ok(mut f) => match f.read_to_end(&mut state_vec) {
-			Ok(len) => {
-				info!("[Enclave] Read {} bytes from state file", len);
-				Ok(state_vec)
-			}
-			Err(x) => {
-				error!("[Enclave] Read encrypted state file failed {}", x);
-				Err(sgx_status_t::SGX_ERROR_UNEXPECTED)
-			}
-		},
-		Err(x) => {
-			info!("[Enclave] No encrypted state file found! {} Err: {}", filepath, x);
-			Ok(state_vec)
-		}
-	}
-}
-
-pub fn write_plaintext(bytes: &[u8], filepath: &str) -> SgxResult<sgx_status_t> {
-	match File::create(filepath) {
-		Ok(mut f) => match f.write_all(bytes) {
-			Ok(()) => {
-				info!("[Enclave] Writing to file '{}' successful", filepath);
-				Ok(sgx_status_t::SGX_SUCCESS)
-			}
-			Err(x) => {
-				error!("[Enclave] Writing to '{}' failed! {}", filepath, x);
-				Err(sgx_status_t::SGX_ERROR_UNEXPECTED)
-			}
-		},
-		Err(x) => {
-			error!("[Enclave] Creating file '{}' error! {}", filepath, x);
-			Err(sgx_status_t::SGX_ERROR_UNEXPECTED)
-		}
-	}
-}
 
 pub fn hash_from_slice(hash_slize: &[u8]) -> Hash {
 	let mut g = [0; 32];
@@ -110,7 +26,7 @@ pub fn hash_from_slice(hash_slize: &[u8]) -> Hash {
 }
 
 pub fn write_slice_and_whitespace_pad(writable: &mut [u8], data: Vec<u8>) {
-		let (left, right) = writable.split_at_mut(data.len());
+	let (left, right) = writable.split_at_mut(data.len());
 	left.clone_from_slice(&data);
 	// fill the right side with whitespace
 	right.iter_mut().for_each(|x| *x = 0x20);

--- a/enclave/src/utils.rs
+++ b/enclave/src/utils.rs
@@ -109,6 +109,13 @@ pub fn hash_from_slice(hash_slize: &[u8]) -> Hash {
 	Hash::from(&mut g)
 }
 
+pub fn write_slice_and_whitespace_pad(writable: &mut [u8], data: Vec<u8>) {
+		let (left, right) = writable.split_at_mut(data.len());
+	left.clone_from_slice(&data);
+	// fill the right side with whitespace
+	right.iter_mut().for_each(|x| *x = 0x20);
+}
+
 /*
 pub fn blake2s(plaintext: &[u8]) -> [u8; 32] {
 	let mut call_hash: [u8; 32] = Default::default();

--- a/substrate-sgx/externalities/Cargo.toml
+++ b/substrate-sgx/externalities/Cargo.toml
@@ -9,3 +9,4 @@ environmental = { version = "1.0.1", default-features = false}
 sgx_tstd      = { rev = "v1.1.0", git = "https://github.com/baidu/rust-sgx-sdk", features = ["untrusted_fs","net","backtrace"]}
 sgx_types     = { rev = "v1.1.0", git = "https://github.com/baidu/rust-sgx-sdk"}
 sgx_log       = { package = "log",  version = "0.4", git = "https://github.com/mesalock-linux/log-sgx"}
+sgx_serialize = { rev = "v1.1.0", git = "https://github.com/baidu/rust-sgx-sdk" }

--- a/substrate-sgx/externalities/src/lib.rs
+++ b/substrate-sgx/externalities/src/lib.rs
@@ -1,15 +1,20 @@
 #![no_std]
 
 extern crate sgx_tstd as std;
-use environmental::environmental;
 
 use std::{collections::HashMap, vec::Vec};
+
+use sgx_serialize::{DeSerializeHelper, SerializeHelper};
+
+use environmental::environmental;
 
 pub type SgxExternalities = HashMap<Vec<u8>, Vec<u8>>;
 environmental!(ext: SgxExternalities);
 
 pub trait SgxExternalitiesTrait {
     fn new() -> Self;
+	fn decode(state: Vec<u8>) -> Self;
+	fn encode(self) -> Vec<u8>;
     fn insert(&mut self, k: Vec<u8>, v: Vec<u8>) -> Option<Vec<u8>>;
     fn execute_with<R>(&mut self, f: impl FnOnce() -> R) -> R;
 }
@@ -19,6 +24,16 @@ impl SgxExternalitiesTrait for SgxExternalities {
     fn new() -> Self {
         SgxExternalities::default()
     }
+
+	fn decode(state: Vec<u8>) -> Self {
+		let helper = DeSerializeHelper::<SgxExternalities>::new(state);
+		helper.decode().unwrap()
+	}
+
+	fn encode(self) -> Vec<u8> {
+		let helper = SerializeHelper::new();
+		helper.encode(self).unwrap()
+	}
 
     /// Insert key/value
     fn insert(&mut self, k: Vec<u8>, v: Vec<u8>) -> Option<Vec<u8>> {

--- a/substrate-sgx/externalities/src/lib.rs
+++ b/substrate-sgx/externalities/src/lib.rs
@@ -12,18 +12,18 @@ pub type SgxExternalities = HashMap<Vec<u8>, Vec<u8>>;
 environmental!(ext: SgxExternalities);
 
 pub trait SgxExternalitiesTrait {
-    fn new() -> Self;
+	fn new() -> Self;
 	fn decode(state: Vec<u8>) -> Self;
 	fn encode(self) -> Vec<u8>;
-    fn insert(&mut self, k: Vec<u8>, v: Vec<u8>) -> Option<Vec<u8>>;
-    fn execute_with<R>(&mut self, f: impl FnOnce() -> R) -> R;
+	fn insert(&mut self, k: Vec<u8>, v: Vec<u8>) -> Option<Vec<u8>>;
+	fn execute_with<R>(&mut self, f: impl FnOnce() -> R) -> R;
 }
 
 impl SgxExternalitiesTrait for SgxExternalities {
-    /// Create a new instance of `BasicExternalities`
-    fn new() -> Self {
-        SgxExternalities::default()
-    }
+	/// Create a new instance of `BasicExternalities`
+	fn new() -> Self {
+		SgxExternalities::default()
+	}
 
 	fn decode(state: Vec<u8>) -> Self {
 		let helper = DeSerializeHelper::<SgxExternalities>::new(state);
@@ -35,31 +35,29 @@ impl SgxExternalitiesTrait for SgxExternalities {
 		helper.encode(self).unwrap()
 	}
 
-    /// Insert key/value
-    fn insert(&mut self, k: Vec<u8>, v: Vec<u8>) -> Option<Vec<u8>> {
-        self.insert(k, v)
-    }
+	/// Insert key/value
+	fn insert(&mut self, k: Vec<u8>, v: Vec<u8>) -> Option<Vec<u8>> {
+		self.insert(k, v)
+	}
 
-    /// Execute the given closure while `self` is set as externalities.
-    ///
-    /// Returns the result of the given closure.
-    fn execute_with<R>(&mut self, f: impl FnOnce() -> R) -> R {
-        set_and_run_with_externalities(self, f)
-    }
+	/// Execute the given closure while `self` is set as externalities.
+	///
+	/// Returns the result of the given closure.
+	fn execute_with<R>(&mut self, f: impl FnOnce() -> R) -> R {
+		set_and_run_with_externalities(self, f)
+	}
 }
 
 /// Set the given externalities while executing the given closure. To get access to the externalities
 /// while executing the given closure [`with_externalities`] grants access to them. The externalities
 /// are only set for the same thread this function was called from.
-pub fn set_and_run_with_externalities<F, R>(ext: &mut SgxExternalities, f: F) -> R
-                                            where F: FnOnce() -> R
-{
-    ext::using(ext, f)
+pub fn set_and_run_with_externalities<F: FnOnce() -> R, R>(ext: &mut SgxExternalities, f: F) -> R {
+	ext::using(ext, f)
 }
 
 /// Execute the given closure with the currently set externalities.
 ///
 /// Returns `None` if no externalities are set or `Some(_)` with the result of the closure.
 pub fn with_externalities<F: FnOnce(&mut SgxExternalities) -> R, R>(f: F) -> Option<R> {
-    ext::with(f)
+	ext::with(f)
 }

--- a/worker/Cargo.toml
+++ b/worker/Cargo.toml
@@ -50,7 +50,6 @@ path = "worker-api"
 git = "https://github.com/scs/substraTEE-node"
 tag = "M5.2"
 package = "substratee-node-runtime"
-default-features = false
 
 [dependencies.runtime_primitives]
 git = "https://github.com/paritytech/substrate"
@@ -86,11 +85,5 @@ path = "../stf"
 default-features = false
 
 [features]
-default = ["std"]
-production = ["std"]
-std = [
-	"primitives/std",
-	"codec/std",
-	"my_node_runtime/std",
-]
-
+default = []
+production = []


### PR DESCRIPTION
* [enclave]: mostly refactoring `utils` into several modules and gave more meaningful and concise names that take into account the namespacing of the modules
* [enclave] also extracted some methods of the `lib.rs` file into modules
* some general cleanup