### PR TITLE
fix-execute-stf

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3217,7 +3217,7 @@ dependencies = [
 [[package]]
 name = "substrate-api-client"
 version = "0.4.2-sub2.0.0-alpha.6"
-source = "git+https://github.com/scs/substrate-api-client?branch=cl-get_signed_block#0766dac01ddf2820df2eb561184fab1ebbcd7a95"
+source = "git+https://github.com/scs/substrate-api-client?branch=cl-get_signed_block#9dbcd79c9771233ae51aaaf932c90cf95f5209ea"
 dependencies = [
  "env_logger 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "frame-metadata 11.0.0-alpha.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3824,7 +3824,7 @@ name = "twox-hash"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.3.23 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/enclave/Cargo.lock
+++ b/enclave/Cargo.lock
@@ -1956,7 +1956,7 @@ dependencies = [
 [[package]]
 name = "substrate-api-client"
 version = "0.4.2-sub2.0.0-alpha.6"
-source = "git+https://github.com/scs/substrate-api-client?branch=cl-get_signed_block#0766dac01ddf2820df2eb561184fab1ebbcd7a95"
+source = "git+https://github.com/scs/substrate-api-client?branch=cl-get_signed_block#9dbcd79c9771233ae51aaaf932c90cf95f5209ea"
 dependencies = [
  "frame-metadata 11.0.0-alpha.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "frame-support 2.0.0-alpha.6 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/enclave/src/lib.rs
+++ b/enclave/src/lib.rs
@@ -246,28 +246,23 @@ pub unsafe extern "C" fn execute_stf(
     let call_hash = blake2_256(&request_vec);
     debug!("Call hash 0x{}", hex::encode_hex(&call_hash));
 
-    let nonce = *nonce;
-    let mut extrinsics_buffer: Vec<Vec<u8>> = Vec::new();
+    let mut nonce = *nonce;
 
-    //TODO: re-enable this but make sure to count up the nonce for subsequent extrinsics!!!!
-
-    /*
-        let mut extrinsic_buffer: Vec<Vec<u8>> = calls_buffer
-            .into_iter()
-            .map(|call| {
-                let xt = compose_extrinsic_offline!(
-                    signer.clone(),
-                    call,
-                    nonce,
-                    genesis_hash,
-                    RUNTIME_SPEC_VERSION
-                )
-                .encode();
-                nonce += 1;
-                xt
-            })
-            .collect();
-    */
+    let mut extrinsics_buffer: Vec<Vec<u8>> = calls_buffer
+        .into_iter()
+        .map(|call| {
+            let xt = compose_extrinsic_offline!(
+                signer.clone(),
+                call,
+                nonce,
+                genesis_hash,
+                RUNTIME_SPEC_VERSION
+            )
+            .encode();
+            nonce += 1;
+            xt
+        })
+        .collect();
 
     let xt_call = [SUBSRATEE_REGISTRY_MODULE, CALL_CONFIRMED];
     extrinsics_buffer.push(

--- a/enclave/src/lib.rs
+++ b/enclave/src/lib.rs
@@ -247,6 +247,7 @@ pub unsafe extern "C" fn execute_stf(
     debug!("Call hash 0x{}", hex::encode_hex(&call_hash));
 
     let nonce = *nonce;
+    let mut extrinsics_buffer: Vec<Vec<u8>> = Vec::new();
 
     //TODO: re-enable this but make sure to count up the nonce for subsequent extrinsics!!!!
 
@@ -269,16 +270,17 @@ pub unsafe extern "C" fn execute_stf(
     */
 
     let xt_call = [SUBSRATEE_REGISTRY_MODULE, CALL_CONFIRMED];
-    //extrinsic_buffer.push(
-    let extrinsic_buffer = compose_extrinsic_offline!(
-        signer,
-        (xt_call, shard, call_hash.to_vec(), state_hash.encode()),
-        nonce,
-        genesis_hash,
-        RUNTIME_SPEC_VERSION
-    )
-    .encode();
-    write_slice_and_whitespace_pad(extrinsic_slice, extrinsic_buffer);
+    extrinsics_buffer.push(
+        compose_extrinsic_offline!(
+            signer,
+            (xt_call, shard, call_hash.to_vec(), state_hash.encode()),
+            nonce,
+            genesis_hash,
+            RUNTIME_SPEC_VERSION
+        )
+        .encode(),
+    );
+    write_slice_and_whitespace_pad(extrinsic_slice, extrinsics_buffer.encode());
 
     sgx_status_t::SGX_SUCCESS
 }

--- a/stf/src/sgx.rs
+++ b/stf/src/sgx.rs
@@ -78,6 +78,11 @@ impl Stf {
                 .unwrap()
             );
 
+            sp_io::storage::set(
+                &nonce_key_hash(call.account()),
+                (nonce + 1).encode().as_slice(),
+            );
+
             let _result = match call {
                 TrustedCall::balance_set_balance(who, free_balance, reserved_balance) => {
                     sgx_runtime::BalancesCall::<Runtime>::set_balance(

--- a/worker/src/main.rs
+++ b/worker/src/main.rs
@@ -415,26 +415,18 @@ pub fn process_request(eid: sgx_enclave_id_t, request: Request, node_url: &str) 
     .unwrap();
     debug!("raw extrinsic returned form enclave {:x?}", uxts);
     info!("[<] Message decoded and processed in the enclave. will send confirmation extrinsic");
-    //let xts = Vec::<UncheckedExtrinsic>::decode(&mut uxts.as_slice()).unwrap();
-    let xt = UncheckedExtrinsic::decode(&mut uxts.as_slice()).unwrap();
-    let mut _xthex = hex::encode(xt.encode());
-    _xthex.insert_str(0, "0x");
-    println!("[>] send an extrinsic composed by enclave");
-    let _hash = api.send_extrinsic(_xthex, XtStatus::Ready).unwrap();
-    debug!("[<] Call confirmation extrinsic sent");
-    /*   TODO: re-enable this:  but beware that you'll have to count up the nonce in stf
-        for subsequent extrinsics from the same address
+    let xts = Vec::<Vec<u8>>::decode(&mut uxts.as_slice()).unwrap();
 
-        info!("enclave requests to send {} extrinsics", xts.len());
-        for xt in xts.iter() {
-            let mut _xthex = hex::encode(xt.encode());
-            _xthex.insert_str(0, "0x");
-            println!("[>] send an extrinsic composed by enclave");
-            let _hash = _api.send_extrinsic(_xthex, XtStatus::Finalized).unwrap();
-            debug!("[<] Request Extrinsic got finalized");
-        }
-        info!("all extrinsics sent.");
-    */
+    info!("enclave requests to send {} extrinsics", xts.len());
+    for xt in xts.iter() {
+        let mut _xthex = hex::encode(xt);
+        _xthex.insert_str(0, "0x");
+        println!("[>] send an extrinsic composed by enclave");
+        // need to put finalized here, else the subsequent tests fetch a nonce that is too low.
+        let _hash = api.send_extrinsic(_xthex, XtStatus::Finalized).unwrap();
+        debug!("[<] Request Extrinsic got finalized");
+    }
+    info!("all extrinsics sent.");
 }
 
 fn init_shard(shard: &ShardIdentifier) {
@@ -576,9 +568,11 @@ pub unsafe extern "C" fn ocall_worker_request(
         .into_iter()
         .map(|req| match req {
             //let res =
-            WorkerRequest::ChainStorage(key) => {
-                WorkerResponse::ChainStorage(key.clone(), api.get_storage_by_key_hash(key), None)
-            }
+            WorkerRequest::ChainStorage(key) => WorkerResponse::ChainStorage(
+                key.clone(),
+                api.get_opaque_storage_by_key_hash(key),
+                None,
+            ),
         })
         .collect();
 

--- a/worker/src/tests/integration_tests.rs
+++ b/worker/src/tests/integration_tests.rs
@@ -112,15 +112,15 @@ pub fn chain_relay(eid: sgx_enclave_id_t, port: &str) {
     let genesis_hash = api.get_genesis_hash();
     let genesis_header: Header = api.get_header(Some(genesis_hash)).unwrap();
 
-    println!("Got genesis Header: \n {:?} \n", genesis_header);
-    println!("Got genesis Parent: \n {:?} \n", genesis_header.parent_hash);
+    info!("Got genesis Header: \n {:?} \n", genesis_header);
+    info!("Got genesis Parent: \n {:?} \n", genesis_header.parent_hash);
 
     let grandpas: AuthorityList = api
         .get_storage_by_key_hash(GRANDPA_AUTHORITIES_KEY.to_vec())
         .map(|g: VersionedAuthorityList| g.into())
         .unwrap();
 
-    println!("Grandpa Authority List: \n {:?} \n ", grandpas);
+    info!("Grandpa Authority List: \n {:?} \n ", grandpas);
 
     enclave_init_chain_relay(eid, genesis_header, VersionedAuthorityList::from(grandpas)).unwrap();
 
@@ -130,7 +130,7 @@ pub fn chain_relay(eid: sgx_enclave_id_t, port: &str) {
         .map(|hash| api.get_signed_block(Some(hash)).unwrap())
         .unwrap();
 
-    println!("Got Finalized Head : \n {:?} \n ", head);
+    info!("Got Finalized Head : \n {:?} \n ", head);
 
     let mut blocks_to_sync = Vec::<SignedBlock>::new();
     blocks_to_sync.push(head.clone());
@@ -141,9 +141,9 @@ pub fn chain_relay(eid: sgx_enclave_id_t, port: &str) {
             .get_signed_block(Some(head.block.header.parent_hash))
             .unwrap();
         blocks_to_sync.push(head.clone());
-        println!("Syncing Block: {}", head.block.header.number)
+        // println!("Syncing Block: {}", head.block.header.number)
     }
     blocks_to_sync.reverse();
-    println!("Got {} headers to sync.", blocks_to_sync.len());
+    // println!("Got {} headers to sync.", blocks_to_sync.len());
     enclave_sync_chain_relay(eid, blocks_to_sync).unwrap();
 }


### PR DESCRIPTION
* fix execute-stf: problem was ocall_worker request. Storage was trying to be decoded into a `Vec<u8>`, which is not possible. Now use `api.get_opaque_storage_by_keyhash` to get directly the storage as `Vec<u8>`

* re-enable extrinsics by the STF