### PR TITLE
Brenzi generic trusted operation returns

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3769,7 +3769,7 @@ checksum = "d2a965994514ab35d3893e9260245f2947fd1981cdd4fffd2c6e6d1a9ce02e6a"
 
 [[package]]
 name = "substratee-client"
-version = "0.6.2-sub2.0.0-alpha.7"
+version = "0.6.3-sub2.0.0-alpha.7"
 dependencies = [
  "base58",
  "blake2-rfc",
@@ -3801,7 +3801,7 @@ dependencies = [
 
 [[package]]
 name = "substratee-node-primitives"
-version = "0.6.2-sub2.0.0-alpha.7"
+version = "0.6.3-sub2.0.0-alpha.7"
 dependencies = [
  "base58",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3873,7 +3873,7 @@ dependencies = [
 
 [[package]]
 name = "substratee-worker"
-version = "0.6.2-sub2.0.0-alpha.7"
+version = "0.6.3-sub2.0.0-alpha.7"
 dependencies = [
  "base58",
  "cid",
@@ -3912,7 +3912,7 @@ dependencies = [
 
 [[package]]
 name = "substratee-worker-api"
-version = "0.6.2-sub2.0.0-alpha.7"
+version = "0.6.3-sub2.0.0-alpha.7"
 dependencies = [
  "hex 0.4.2",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -38,7 +38,6 @@ use clap::{Arg, ArgMatches};
 use clap_nested::{Command, Commander};
 use codec::{Decode, Encode};
 use log::*;
-use primitive_types::U256;
 use sp_core::{crypto::Ss58Codec, hashing::blake2_256, sr25519 as sr25519_core, Pair, H256};
 use sp_runtime::{
     traits::{IdentifyAccount, Verify},
@@ -436,7 +435,10 @@ fn get_worker_api(matches: &ArgMatches<'_>) -> WorkerApi {
     WorkerApi::new(url)
 }
 
-fn perform_trusted_operation(matches: &ArgMatches<'_>, top: &TrustedOperationSigned) -> Option<Vec<u8>> {
+fn perform_trusted_operation(
+    matches: &ArgMatches<'_>,
+    top: &TrustedOperationSigned,
+) -> Option<Vec<u8>> {
     match top {
         TrustedOperationSigned::call(call) => send_request(matches, call.clone()),
         TrustedOperationSigned::get(getter) => get_state(matches, getter.clone()),
@@ -452,8 +454,12 @@ fn get_state(matches: &ArgMatches<'_>, getter: TrustedGetterSigned) -> Option<Ve
         .expect("getting value failed");
     // strip whitespace padding through decoding
     if let Ok(vd) = Decode::decode(&mut ret.as_slice()) {
-        Some(vd)
-    } else { None }
+        debug!("decoded return value: {:?} ", vd);
+        vd
+    } else {
+        debug!("decoding failed");
+        None
+    }
 }
 
 fn send_request(matches: &ArgMatches<'_>, call: TrustedCallSigned) -> Option<Vec<u8>> {

--- a/enclave/Cargo.lock
+++ b/enclave/Cargo.lock
@@ -172,7 +172,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "chain-relay"
-version = "0.6.2-sub2.0.0-alpha.7"
+version = "0.6.3-sub2.0.0-alpha.7"
 dependencies = [
  "derive_more 0.99.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "finality-grandpa 0.11.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2038,7 +2038,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "substratee-node-primitives"
-version = "0.6.2-sub2.0.0-alpha.7"
+version = "0.6.3-sub2.0.0-alpha.7"
 dependencies = [
  "parity-scale-codec 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "primitive-types 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2066,12 +2066,12 @@ dependencies = [
 
 [[package]]
 name = "substratee-worker-enclave"
-version = "0.6.2-sub2.0.0-alpha.7"
+version = "0.6.3-sub2.0.0-alpha.7"
 dependencies = [
  "aes 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "base64 0.10.1 (git+https://github.com/mesalock-linux/rust-base64-sgx)",
  "bit-vec 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "chain-relay 0.6.2-sub2.0.0-alpha.7",
+ "chain-relay 0.6.3-sub2.0.0-alpha.7",
  "chrono 0.4.11 (git+https://github.com/mesalock-linux/chrono-sgx)",
  "env_logger 0.7.1 (git+https://github.com/mesalock-linux/env_logger-sgx)",
  "httparse 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2105,7 +2105,7 @@ dependencies = [
  "sp-runtime 2.0.0-alpha.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "sp-std 2.0.0-alpha.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "substrate-api-client 0.4.6-sub2.0.0-alpha.7 (git+https://github.com/scs/substrate-api-client?tag=v0.4.6-sub2.0.0-alpha.7)",
- "substratee-node-primitives 0.6.2-sub2.0.0-alpha.7",
+ "substratee-node-primitives 0.6.3-sub2.0.0-alpha.7",
  "substratee-stf 0.2.0",
  "webpki 0.21.2 (git+https://github.com/mesalock-linux/webpki?branch=mesalock_sgx)",
  "webpki-roots 0.19.0 (git+https://github.com/mesalock-linux/webpki-roots?branch=mesalock_sgx)",

--- a/enclave/src/lib.rs
+++ b/enclave/src/lib.rs
@@ -403,11 +403,11 @@ fn handle_call_worker_xt(
     let rsa_keypair = rsa3072::unseal_pair()?;
     let request_vec = rsa3072::decrypt(&cyphertext, &rsa_keypair)?;
     let stf_call_signed = if let Ok(call) = TrustedCallSigned::decode(&mut request_vec.as_slice()) {
-        call 
-    } else { 
+        call
+    } else {
         error!("could not decode TrustedCallSigned");
         // do not panic here or users will be able to shoot workers dead by supplying funky calls
-        return Ok(())
+        return Ok(());
     };
 
     debug!("query mrenclave of self");

--- a/stf/src/cli.rs
+++ b/stf/src/cli.rs
@@ -23,14 +23,14 @@ use codec::Encode;
 use log::*;
 use sc_keystore::Store;
 use sp_application_crypto::{ed25519, sr25519};
-use sp_core::{crypto::Ss58Codec, sr25519 as sr25519_core, Pair};
+use sp_core::{crypto::Ss58Codec, sr25519 as sr25519_core, Pair, H256};
 use sp_runtime::traits::IdentifyAccount;
 use std::path::PathBuf;
 
 const KEYSTORE_PATH: &str = "my_trusted_keystore";
 
 pub fn cmd<'a>(
-    perform_operation: &'a dyn Fn(&ArgMatches<'_>, &TrustedOperationSigned),
+    perform_operation: &'a dyn Fn<R>(&ArgMatches<'_>, &TrustedOperationSigned) -> Option<R>,
 ) -> MultiCommand<'a, str, str> {
     Commander::new()
         .options(|app| {
@@ -154,7 +154,7 @@ pub fn cmd<'a>(
                         to,
                         amount
                     );
-                    perform_operation(matches, &TrustedOperationSigned::call(tscall));
+                    let _: Option<H256> = perform_operation(matches, &TrustedOperationSigned::call(tscall));
                     Ok(())
                 }),
         )
@@ -201,7 +201,7 @@ pub fn cmd<'a>(
                         tscall.call.account(),
                         amount
                     );
-                    perform_operation(matches, &TrustedOperationSigned::call(tscall));
+                    let _ : Option<H256> = perform_operation(matches, &TrustedOperationSigned::call(tscall));
                     Ok(())
                 }),
         )
@@ -224,7 +224,9 @@ pub fn cmd<'a>(
                     let tgetter =
                         TrustedGetter::free_balance(sr25519_core::Public::from(who.public()));
                     let tsgetter = tgetter.sign(&sr25519_core::Pair::from(who));
-                    perform_operation(matches, &TrustedOperationSigned::get(tsgetter));
+                    let res: Option<i128> = perform_operation(matches, &TrustedOperationSigned::get(tsgetter));
+                    let bal = if let Some(bal) = res { bal } else { 0 };
+                    println!("{}", bal);
                     Ok(())
                 }),
         )

--- a/stf/src/cli.rs
+++ b/stf/src/cli.rs
@@ -19,11 +19,11 @@ use crate::{AccountId, ShardIdentifier, TrustedCall, TrustedGetter, TrustedOpera
 use base58::{FromBase58, ToBase58};
 use clap::{Arg, ArgMatches};
 use clap_nested::{Command, Commander, MultiCommand};
-use codec::{Encode, Decode};
+use codec::{Decode, Encode};
 use log::*;
 use sc_keystore::Store;
 use sp_application_crypto::{ed25519, sr25519};
-use sp_core::{crypto::Ss58Codec, sr25519 as sr25519_core, Pair, H256};
+use sp_core::{crypto::Ss58Codec, sr25519 as sr25519_core, Pair};
 use sp_runtime::traits::IdentifyAccount;
 use std::path::PathBuf;
 
@@ -225,12 +225,16 @@ pub fn cmd<'a>(
                         TrustedGetter::free_balance(sr25519_core::Public::from(who.public()));
                     let tsgetter = tgetter.sign(&sr25519_core::Pair::from(who));
                     let res = perform_operation(matches, &TrustedOperationSigned::get(tsgetter));
-                    let bal = if let Some(v) = res { 
-                        if let Ok(vd) = crate::Balance::decode(&mut v.as_slice()) { vd } else {
+                    let bal = if let Some(v) = res {
+                        if let Ok(vd) = crate::Balance::decode(&mut v.as_slice()) {
+                            vd
+                        } else {
                             info!("could not decode value. maybe hasn't been set? {:x?}", v);
                             0
                         }
-                    } else { 0 };
+                    } else {
+                        0
+                    };
                     println!("{}", bal);
                     Ok(())
                 }),

--- a/stf/src/cli.rs
+++ b/stf/src/cli.rs
@@ -19,7 +19,7 @@ use crate::{AccountId, ShardIdentifier, TrustedCall, TrustedGetter, TrustedOpera
 use base58::{FromBase58, ToBase58};
 use clap::{Arg, ArgMatches};
 use clap_nested::{Command, Commander, MultiCommand};
-use codec::Encode;
+use codec::{Encode, Decode};
 use log::*;
 use sc_keystore::Store;
 use sp_application_crypto::{ed25519, sr25519};
@@ -30,7 +30,7 @@ use std::path::PathBuf;
 const KEYSTORE_PATH: &str = "my_trusted_keystore";
 
 pub fn cmd<'a>(
-    perform_operation: &'a dyn Fn<R>(&ArgMatches<'_>, &TrustedOperationSigned) -> Option<R>,
+    perform_operation: &'a dyn Fn(&ArgMatches<'_>, &TrustedOperationSigned) -> Option<Vec<u8>>,
 ) -> MultiCommand<'a, str, str> {
     Commander::new()
         .options(|app| {
@@ -154,7 +154,7 @@ pub fn cmd<'a>(
                         to,
                         amount
                     );
-                    let _: Option<H256> = perform_operation(matches, &TrustedOperationSigned::call(tscall));
+                    let _ = perform_operation(matches, &TrustedOperationSigned::call(tscall));
                     Ok(())
                 }),
         )
@@ -201,7 +201,7 @@ pub fn cmd<'a>(
                         tscall.call.account(),
                         amount
                     );
-                    let _ : Option<H256> = perform_operation(matches, &TrustedOperationSigned::call(tscall));
+                    let _ = perform_operation(matches, &TrustedOperationSigned::call(tscall));
                     Ok(())
                 }),
         )
@@ -224,8 +224,13 @@ pub fn cmd<'a>(
                     let tgetter =
                         TrustedGetter::free_balance(sr25519_core::Public::from(who.public()));
                     let tsgetter = tgetter.sign(&sr25519_core::Pair::from(who));
-                    let res: Option<i128> = perform_operation(matches, &TrustedOperationSigned::get(tsgetter));
-                    let bal = if let Some(bal) = res { bal } else { 0 };
+                    let res = perform_operation(matches, &TrustedOperationSigned::get(tsgetter));
+                    let bal = if let Some(v) = res { 
+                        if let Ok(vd) = crate::Balance::decode(&mut v.as_slice()) { vd } else {
+                            info!("could not decode value. maybe hasn't been set? {:x?}", v);
+                            0
+                        }
+                    } else { 0 };
                     println!("{}", bal);
                     Ok(())
                 }),

--- a/worker/src/cli.yml
+++ b/worker/src/cli.yml
@@ -41,8 +41,8 @@ subcommands:
         about: Start the substraTEE-worker
         args:
             - shard:
-                short: s
-                long: shard
+                required: false
+                index: 1
                 help: shard identifier base58 encoded. Defines the state that this worker shall operate on. Default is mrenclave
     - shielding-key:
         about: Get the public RSA3072 key from the TEE to be used to encrypt requests

--- a/worker/src/main.rs
+++ b/worker/src/main.rs
@@ -159,10 +159,7 @@ fn main() {
         match _matches.values_of("shard") {
             Some(values) => {
                 for shard in values {
-                    if shard.len() != 2 * 32 {
-                        panic!("shard must be 256bit hex string")
-                    }
-                    match hex::decode(shard) {
+                    match shard.from_base58() {
                         Ok(s) => {
                             init_shard(&ShardIdentifier::from_slice(&s[..]));
                         }

--- a/worker/src/ws_server.rs
+++ b/worker/src/ws_server.rs
@@ -82,6 +82,7 @@ fn handle_get_stf_state_msg(eid: sgx_enclave_id_t, getter_str: &str, shard_str: 
             None
         }
     };
+    // we could strip the whitespace padding here, but actually constant message size is a privacy feature!
     debug!("get_state result: {:?}", value);
     Message::text(hex::encode(value.encode()))
 }

--- a/worker/worker-api/src/lib.rs
+++ b/worker/worker-api/src/lib.rs
@@ -66,12 +66,11 @@ impl Api {
         let request = format!("{}::{}::{}", MSG_GET_STF_STATE, getter_str, shard_str);
         match Self::get(&self, &request) {
             Ok(res) => {
-                debug!("got a response from worker: {:?}", res);
                 let value_slice = hex::decode(&res).unwrap();
                 let value: Option<Vec<u8>> = Decode::decode(&mut &value_slice[..]).unwrap();
                 match value {
-                    Some(val) => Ok(val),  // val is still an encoded option! can be None.encode() if storage doesn't exist
-                    None => Err(()), // there must've been an SgxResult::Err inside enclave
+                    Some(val) => Ok(val), // val is still an encoded option! can be None.encode() if storage doesn't exist
+                    None => Err(()),      // there must've been an SgxResult::Err inside enclave
                 }
             }
             Err(_) => Err(()), // ws error

--- a/worker/worker-api/src/lib.rs
+++ b/worker/worker-api/src/lib.rs
@@ -70,11 +70,11 @@ impl Api {
                 let value_slice = hex::decode(&res).unwrap();
                 let value: Option<Vec<u8>> = Decode::decode(&mut &value_slice[..]).unwrap();
                 match value {
-                    Some(val) => Ok(val),
-                    None => Err(()),
+                    Some(val) => Ok(val),  // val is still an encoded option! can be None.encode() if storage doesn't exist
+                    None => Err(()), // there must've been an SgxResult::Err inside enclave
                 }
             }
-            Err(_) => Err(()),
+            Err(_) => Err(()), // ws error
         }
     }
 


### PR DESCRIPTION
+ generic return values for TrustedGetter (still maximum-sized)
! fix init-shard cli to use base58 encoding
! prevent panics causes by TrustedCalls
