### PR TITLE
update deps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1183,7 +1183,7 @@ dependencies = [
 [[package]]
 name = "ias-verify"
 version = "0.1.0"
-source = "git+https://github.com/scs/pallet-substratee-registry.git?tag=v0.6.5-sub2.0.0-alpha.7#9d664bbb96e7b529dcb66abf661b2564a3d8f609"
+source = "git+https://github.com/scs/pallet-substratee-registry.git?tag=v0.6.7-sub2.0.0-alpha.7#c4bcb69975b96a52a68b95a852d3c4a02c84c241"
 dependencies = [
  "base64",
  "chrono",
@@ -1968,15 +1968,17 @@ dependencies = [
 
 [[package]]
 name = "pallet-substratee-registry"
-version = "0.6.5-sub2.0.0-alpha.7"
-source = "git+https://github.com/scs/pallet-substratee-registry.git?tag=v0.6.5-sub2.0.0-alpha.7#9d664bbb96e7b529dcb66abf661b2564a3d8f609"
+version = "0.6.7-sub2.0.0-alpha.7"
+source = "git+https://github.com/scs/pallet-substratee-registry.git?tag=v0.6.7-sub2.0.0-alpha.7#c4bcb69975b96a52a68b95a852d3c4a02c84c241"
 dependencies = [
  "frame-support",
  "frame-system",
  "ias-verify",
+ "pallet-timestamp",
  "parity-scale-codec",
  "sp-core",
  "sp-io 2.0.0-alpha.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-runtime",
  "sp-std",
 ]
 
@@ -3816,8 +3818,8 @@ dependencies = [
 
 [[package]]
 name = "substratee-node-runtime"
-version = "0.6.3-sub2.0.0-alpha.7"
-source = "git+https://github.com/scs/substraTEE-node?tag=v0.6.3-sub2.0.0-alpha.7#b75d1fe59d8ca8764ca486b3c5ca19e0ba9a8039"
+version = "0.6.5-sub2.0.0-alpha.7"
+source = "git+https://github.com/scs/substraTEE-node?tag=v0.6.5-sub2.0.0-alpha.7#6b0ef0b840c34e0a9beb418125a6dc7904a7862c"
 dependencies = [
  "frame-executive",
  "frame-support",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3771,7 +3771,7 @@ checksum = "d2a965994514ab35d3893e9260245f2947fd1981cdd4fffd2c6e6d1a9ce02e6a"
 
 [[package]]
 name = "substratee-client"
-version = "0.6.3-sub2.0.0-alpha.7"
+version = "0.6.4-sub2.0.0-alpha.7"
 dependencies = [
  "base58",
  "blake2-rfc",
@@ -3803,7 +3803,7 @@ dependencies = [
 
 [[package]]
 name = "substratee-node-primitives"
-version = "0.6.3-sub2.0.0-alpha.7"
+version = "0.6.4-sub2.0.0-alpha.7"
 dependencies = [
  "base58",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3851,7 +3851,7 @@ dependencies = [
 
 [[package]]
 name = "substratee-stf"
-version = "0.2.0"
+version = "0.6.4-sub2.0.0-alpha.7"
 dependencies = [
  "base58",
  "clap",
@@ -3876,7 +3876,7 @@ dependencies = [
 
 [[package]]
 name = "substratee-worker"
-version = "0.6.3-sub2.0.0-alpha.7"
+version = "0.6.4-sub2.0.0-alpha.7"
 dependencies = [
  "base58",
  "cid",
@@ -3915,7 +3915,7 @@ dependencies = [
 
 [[package]]
 name = "substratee-worker-api"
-version = "0.6.3-sub2.0.0-alpha.7"
+version = "0.6.4-sub2.0.0-alpha.7"
 dependencies = [
  "hex 0.4.2",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1998,7 +1998,7 @@ dependencies = [
 [[package]]
 name = "pallet-template"
 version = "2.0.0-alpha.7"
-source = "git+https://github.com/scs/sgx-runtime#32f212bbefffc095bb5ef470b86fd7f776338dbb"
+source = "git+https://github.com/scs/sgx-runtime?tag=v2.0.0-alpha.7#32f212bbefffc095bb5ef470b86fd7f776338dbb"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -2960,7 +2960,7 @@ dependencies = [
 [[package]]
 name = "sgx-runtime"
 version = "2.0.0-alpha.7"
-source = "git+https://github.com/scs/sgx-runtime#32f212bbefffc095bb5ef470b86fd7f776338dbb"
+source = "git+https://github.com/scs/sgx-runtime?tag=v2.0.0-alpha.7#32f212bbefffc095bb5ef470b86fd7f776338dbb"
 dependencies = [
  "frame-executive",
  "frame-support",
@@ -3714,7 +3714,7 @@ dependencies = [
 [[package]]
 name = "substrate-api-client"
 version = "0.4.6-sub2.0.0-alpha.7"
-source = "git+https://github.com/scs/substrate-api-client?tag=v0.4.6-sub2.0.0-alpha.7#3546fc10f88008a68ba102adbcea66e75ffc5885"
+source = "git+https://github.com/scs/substrate-api-client?tag=v0.4.6-sub2.0.0-alpha.7#cce8441c09224ab641619ea077b5b7fb118f6bf6"
 dependencies = [
  "env_logger 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "frame-metadata",

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "substratee-client"
-version = "0.6.3-sub2.0.0-alpha.7"
+version = "0.6.4-sub2.0.0-alpha.7"
 authors = ["Supercomputing Systems AG <info@scs.ch>"]
 edition = "2018"
 

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -53,7 +53,7 @@ default-features=false
 
 [dependencies.substratee-node-runtime]
 git = "https://github.com/scs/substraTEE-node"
-tag = "v0.6.3-sub2.0.0-alpha.7"
+tag = "v0.6.5-sub2.0.0-alpha.7"
 package = "substratee-node-runtime"
 
 [dependencies.substratee-stf]

--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -291,7 +291,7 @@ fn main() {
                         };
                         let enclave = enclave.unwrap();
                         let timestamp = DateTime::<Utc>::from(
-                            UNIX_EPOCH + Duration::from_secs(enclave.timestamp as u64),
+                            UNIX_EPOCH + Duration::from_millis(enclave.timestamp as u64),
                         );
                         println!("Enclave {}", w);
                         println!("   AccountId: {}", enclave.pubkey.to_ss58check());
@@ -514,6 +514,9 @@ fn send_request(matches: &ArgMatches<'_>, call: TrustedCallSigned) -> Option<Vec
     let mut decoder = EventsDecoder::try_from(_chain_api.metadata.clone()).unwrap();
     decoder
         .register_type_size::<Hash>("ShardIdentifier")
+        .unwrap();
+    decoder
+        .register_type_size::<(Hash, Vec<u8>)>("Request")
         .unwrap();
 
     loop {

--- a/enclave/Cargo.lock
+++ b/enclave/Cargo.lock
@@ -2046,7 +2046,7 @@ dependencies = [
 [[package]]
 name = "substrate-api-client"
 version = "0.4.6-sub2.0.0-alpha.7"
-source = "git+https://github.com/scs/substrate-api-client?tag=v0.4.6-sub2.0.0-alpha.7#3546fc10f88008a68ba102adbcea66e75ffc5885"
+source = "git+https://github.com/scs/substrate-api-client?tag=v0.4.6-sub2.0.0-alpha.7#cce8441c09224ab641619ea077b5b7fb118f6bf6"
 dependencies = [
  "frame-metadata 11.0.0-alpha.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "frame-support 2.0.0-alpha.7 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/enclave/Cargo.lock
+++ b/enclave/Cargo.lock
@@ -963,7 +963,7 @@ dependencies = [
 [[package]]
 name = "pallet-template"
 version = "2.0.0-alpha.7"
-source = "git+https://github.com/scs/sgx-runtime#32f212bbefffc095bb5ef470b86fd7f776338dbb"
+source = "git+https://github.com/scs/sgx-runtime?tag=v2.0.0-alpha.7#32f212bbefffc095bb5ef470b86fd7f776338dbb"
 dependencies = [
  "frame-support 2.0.0-alpha.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "frame-system 2.0.0-alpha.7 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1433,6 +1433,18 @@ dependencies = [
 [[package]]
 name = "sgx-externalities"
 version = "0.2.0"
+source = "git+https://github.com/scs/sgx-runtime?tag=v2.0.0-alpha.7#32f212bbefffc095bb5ef470b86fd7f776338dbb"
+dependencies = [
+ "environmental 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.8 (git+https://github.com/mesalock-linux/log-sgx)",
+ "sgx_serialize 1.1.2 (git+https://github.com/apache/teaclave-sgx-sdk.git?rev=v1.1.2)",
+ "sgx_tstd 1.1.2 (git+https://github.com/apache/teaclave-sgx-sdk.git?rev=v1.1.2)",
+ "sgx_types 1.1.2 (git+https://github.com/apache/teaclave-sgx-sdk.git?rev=v1.1.2)",
+]
+
+[[package]]
+name = "sgx-externalities"
+version = "0.2.0"
 source = "git+https://github.com/scs/sgx-runtime#32f212bbefffc095bb5ef470b86fd7f776338dbb"
 dependencies = [
  "environmental 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1445,7 +1457,7 @@ dependencies = [
 [[package]]
 name = "sgx-runtime"
 version = "2.0.0-alpha.7"
-source = "git+https://github.com/scs/sgx-runtime#32f212bbefffc095bb5ef470b86fd7f776338dbb"
+source = "git+https://github.com/scs/sgx-runtime?tag=v2.0.0-alpha.7#32f212bbefffc095bb5ef470b86fd7f776338dbb"
 dependencies = [
  "frame-executive 2.0.0-alpha.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "frame-support 2.0.0-alpha.7 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1455,7 +1467,7 @@ dependencies = [
  "pallet-grandpa 2.0.0-alpha.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "pallet-randomness-collective-flip 2.0.0-alpha.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "pallet-sudo 2.0.0-alpha.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "pallet-template 2.0.0-alpha.7 (git+https://github.com/scs/sgx-runtime)",
+ "pallet-template 2.0.0-alpha.7 (git+https://github.com/scs/sgx-runtime?tag=v2.0.0-alpha.7)",
  "pallet-timestamp 2.0.0-alpha.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "pallet-transaction-payment 2.0.0-alpha.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1818,6 +1830,24 @@ dependencies = [
 [[package]]
 name = "sp-io"
 version = "2.0.0-alpha.7"
+source = "git+https://github.com/scs/sgx-runtime?tag=v2.0.0-alpha.7#32f212bbefffc095bb5ef470b86fd7f776338dbb"
+dependencies = [
+ "environmental 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hash-db 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.8 (git+https://github.com/mesalock-linux/log-sgx)",
+ "parity-scale-codec 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sgx-externalities 0.2.0 (git+https://github.com/scs/sgx-runtime?tag=v2.0.0-alpha.7)",
+ "sgx_tstd 1.1.2 (git+https://github.com/apache/teaclave-sgx-sdk.git?rev=v1.1.2)",
+ "sgx_types 1.1.2 (git+https://github.com/apache/teaclave-sgx-sdk.git?rev=v1.1.2)",
+ "sp-core 2.0.0-alpha.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-runtime-interface 2.0.0-alpha.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-std 2.0.0-alpha.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-wasm-interface 2.0.0-alpha.7 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "sp-io"
+version = "2.0.0-alpha.7"
 source = "git+https://github.com/scs/sgx-runtime#32f212bbefffc095bb5ef470b86fd7f776338dbb"
 dependencies = [
  "environmental 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2057,7 +2087,7 @@ dependencies = [
  "log 0.4.8 (git+https://github.com/mesalock-linux/log-sgx)",
  "pallet-balances 2.0.0-alpha.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sgx-runtime 2.0.0-alpha.7 (git+https://github.com/scs/sgx-runtime)",
+ "sgx-runtime 2.0.0-alpha.7 (git+https://github.com/scs/sgx-runtime?tag=v2.0.0-alpha.7)",
  "sgx_tstd 1.1.2 (git+https://github.com/apache/teaclave-sgx-sdk.git?rev=v1.1.2)",
  "sp-application-crypto 2.0.0-alpha.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "sp-core 2.0.0-alpha.7 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2102,7 +2132,7 @@ dependencies = [
  "sgx_types 1.1.2 (git+https://github.com/apache/teaclave-sgx-sdk.git?rev=v1.1.2)",
  "sp-core 2.0.0-alpha.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "sp-finality-grandpa 2.0.0-alpha.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-io 2.0.0-alpha.7 (git+https://github.com/scs/sgx-runtime)",
+ "sp-io 2.0.0-alpha.7 (git+https://github.com/scs/sgx-runtime?tag=v2.0.0-alpha.7)",
  "sp-runtime 2.0.0-alpha.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "sp-std 2.0.0-alpha.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "substrate-api-client 0.4.6-sub2.0.0-alpha.7 (git+https://github.com/scs/substrate-api-client?tag=v0.4.6-sub2.0.0-alpha.7)",
@@ -2455,7 +2485,7 @@ dependencies = [
 "checksum pallet-randomness-collective-flip 2.0.0-alpha.7 (registry+https://github.com/rust-lang/crates.io-index)" = "e6f06234e000e7b7554d75d62280e953f902981196d6dcde0d084ad5c7df4809"
 "checksum pallet-session 2.0.0-alpha.7 (registry+https://github.com/rust-lang/crates.io-index)" = "6aace05f197abe3905182ec817e6fadc3c985b3c2ec41bfc74bb9918d1585e9e"
 "checksum pallet-sudo 2.0.0-alpha.7 (registry+https://github.com/rust-lang/crates.io-index)" = "246c9c0b5c29baff01d925ebadee6c0c642fa4c56ba8de1957f1ecc1438cc7dc"
-"checksum pallet-template 2.0.0-alpha.7 (git+https://github.com/scs/sgx-runtime)" = "<none>"
+"checksum pallet-template 2.0.0-alpha.7 (git+https://github.com/scs/sgx-runtime?tag=v2.0.0-alpha.7)" = "<none>"
 "checksum pallet-timestamp 2.0.0-alpha.7 (registry+https://github.com/rust-lang/crates.io-index)" = "4c90b652dfb8796d657a2df5fa6200ada33b9784554b81a32efd73de2fe00575"
 "checksum pallet-transaction-payment 2.0.0-alpha.7 (registry+https://github.com/rust-lang/crates.io-index)" = "52333b8598b2bcb3af5e158c61cb2d30821220a5034e92a74c6a4ef116d82a7f"
 "checksum pallet-transaction-payment-rpc-runtime-api 2.0.0-alpha.7 (registry+https://github.com/rust-lang/crates.io-index)" = "40f6cc2ebdaff949b9f38cc03f19e541bd22773ce32e84532ac1d85a481cb112"
@@ -2509,7 +2539,8 @@ dependencies = [
 "checksum serde_derive 1.0.110 (registry+https://github.com/rust-lang/crates.io-index)" = "818fbf6bfa9a42d3bfcaca148547aa00c7b915bec71d1757aa2d44ca68771984"
 "checksum serde_json 1.0.51 (git+https://github.com/mesalock-linux/serde-json-sgx?rev=sgx_1.1.2)" = "<none>"
 "checksum sgx-externalities 0.2.0 (git+https://github.com/scs/sgx-runtime)" = "<none>"
-"checksum sgx-runtime 2.0.0-alpha.7 (git+https://github.com/scs/sgx-runtime)" = "<none>"
+"checksum sgx-externalities 0.2.0 (git+https://github.com/scs/sgx-runtime?tag=v2.0.0-alpha.7)" = "<none>"
+"checksum sgx-runtime 2.0.0-alpha.7 (git+https://github.com/scs/sgx-runtime?tag=v2.0.0-alpha.7)" = "<none>"
 "checksum sgx_alloc 1.1.2 (git+https://github.com/apache/teaclave-sgx-sdk.git?rev=v1.1.2)" = "<none>"
 "checksum sgx_backtrace_sys 1.1.2 (git+https://github.com/apache/teaclave-sgx-sdk.git?rev=v1.1.2)" = "<none>"
 "checksum sgx_build_helper 0.1.3 (git+https://github.com/apache/teaclave-sgx-sdk.git?rev=v1.1.2)" = "<none>"
@@ -2545,6 +2576,7 @@ dependencies = [
 "checksum sp-finality-tracker 2.0.0-alpha.7 (registry+https://github.com/rust-lang/crates.io-index)" = "8f050f19f1e07b63f61a872552fecf7239c75e77dc133a5f5ae00dac0e7b348d"
 "checksum sp-inherents 2.0.0-alpha.7 (registry+https://github.com/rust-lang/crates.io-index)" = "8367b0e285f8c3ab00400a5f5b53ff0dba263005d2458fdc3e9652f824205f0b"
 "checksum sp-io 2.0.0-alpha.7 (git+https://github.com/scs/sgx-runtime)" = "<none>"
+"checksum sp-io 2.0.0-alpha.7 (git+https://github.com/scs/sgx-runtime?tag=v2.0.0-alpha.7)" = "<none>"
 "checksum sp-offchain 2.0.0-alpha.7 (registry+https://github.com/rust-lang/crates.io-index)" = "e63092c0ecd8fc90971a14a169f62337b78d885873e55dee87f33fe5f76d6591"
 "checksum sp-runtime 2.0.0-alpha.7 (registry+https://github.com/rust-lang/crates.io-index)" = "0d37f6a2e111dd82dd194fa9ef77ba49b17e70162afc237f99e7c5dc6f95834f"
 "checksum sp-runtime-interface 2.0.0-alpha.7 (registry+https://github.com/rust-lang/crates.io-index)" = "bc743ea280556cbaf82203ec63ade39f4167402cb571aaf012c6c43f092ccf33"

--- a/enclave/Cargo.lock
+++ b/enclave/Cargo.lock
@@ -172,7 +172,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "chain-relay"
-version = "0.6.3-sub2.0.0-alpha.7"
+version = "0.6.4-sub2.0.0-alpha.7"
 dependencies = [
  "derive_more 0.99.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "finality-grandpa 0.11.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2068,7 +2068,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "substratee-node-primitives"
-version = "0.6.3-sub2.0.0-alpha.7"
+version = "0.6.4-sub2.0.0-alpha.7"
 dependencies = [
  "parity-scale-codec 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "primitive-types 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2078,7 +2078,7 @@ dependencies = [
 
 [[package]]
 name = "substratee-stf"
-version = "0.2.0"
+version = "0.6.4-sub2.0.0-alpha.7"
 dependencies = [
  "derive_more 0.99.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.7.1 (git+https://github.com/mesalock-linux/env_logger-sgx)",
@@ -2097,12 +2097,12 @@ dependencies = [
 
 [[package]]
 name = "substratee-worker-enclave"
-version = "0.6.3-sub2.0.0-alpha.7"
+version = "0.6.4-sub2.0.0-alpha.7"
 dependencies = [
  "aes 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "base64 0.10.1 (git+https://github.com/mesalock-linux/rust-base64-sgx)",
  "bit-vec 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "chain-relay 0.6.3-sub2.0.0-alpha.7",
+ "chain-relay 0.6.4-sub2.0.0-alpha.7",
  "chrono 0.4.11 (git+https://github.com/mesalock-linux/chrono-sgx)",
  "env_logger 0.7.1 (git+https://github.com/mesalock-linux/env_logger-sgx)",
  "httparse 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2136,8 +2136,8 @@ dependencies = [
  "sp-runtime 2.0.0-alpha.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "sp-std 2.0.0-alpha.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "substrate-api-client 0.4.6-sub2.0.0-alpha.7 (git+https://github.com/scs/substrate-api-client?tag=v0.4.6-sub2.0.0-alpha.7)",
- "substratee-node-primitives 0.6.3-sub2.0.0-alpha.7",
- "substratee-stf 0.2.0",
+ "substratee-node-primitives 0.6.4-sub2.0.0-alpha.7",
+ "substratee-stf 0.6.4-sub2.0.0-alpha.7",
  "webpki 0.21.2 (git+https://github.com/mesalock-linux/webpki?branch=mesalock_sgx)",
  "webpki-roots 0.19.0 (git+https://github.com/mesalock-linux/webpki-roots?branch=mesalock_sgx)",
  "yasna 0.3.1 (git+https://github.com/mesalock-linux/yasna.rs-sgx?rev=sgx_1.1.2)",

--- a/enclave/Cargo.toml
+++ b/enclave/Cargo.toml
@@ -73,6 +73,7 @@ features = ["dangerous_configuration"]
 
 [dependencies.sp-io]
 git = "https://github.com/scs/sgx-runtime"
+tag = "v2.0.0-alpha.7"
 default-features = false
 optional = true
 package = "sp-io"

--- a/enclave/Cargo.toml
+++ b/enclave/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "substratee-worker-enclave"
-version = "0.6.3-sub2.0.0-alpha.7"
+version = "0.6.4-sub2.0.0-alpha.7"
 authors = ["Supercomputing Systems AG <info@scs.ch>"]
 edition = "2018"
 

--- a/enclave/chain_relay/Cargo.toml
+++ b/enclave/chain_relay/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chain-relay"
-version = "0.6.3-sub2.0.0-alpha.7"
+version = "0.6.4-sub2.0.0-alpha.7"
 authors = ["Supercomputing Systems AG <info@scs.ch>"]
 edition = "2018"
 

--- a/enclave/src/attestation.rs
+++ b/enclave/src/attestation.rs
@@ -644,6 +644,8 @@ pub unsafe extern "C" fn perform_ra(
         signer,
         (call, cert_der.to_vec(), url_slice.to_vec()),
         *nonce,
+        Era::Immortal,
+        genesis_hash,
         genesis_hash,
         RUNTIME_SPEC_VERSION
     );

--- a/enclave/src/lib.rs
+++ b/enclave/src/lib.rs
@@ -174,6 +174,8 @@ fn stf_post_actions(
                 signer.clone(),
                 call,
                 nonce,
+                Era::Immortal,
+                validator.genesis_hash(validator.num_relays).unwrap(),
                 validator.genesis_hash(validator.num_relays).unwrap(),
                 RUNTIME_SPEC_VERSION
             )

--- a/stf/Cargo.toml
+++ b/stf/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "substratee-stf"
-version = "0.2.0"
+version = "0.6.4-sub2.0.0-alpha.7"
 authors = ["Supercomputing Systems AG <info@scs.ch>"]
 edition = "2018"
 

--- a/stf/Cargo.toml
+++ b/stf/Cargo.toml
@@ -85,7 +85,7 @@ features = ["disable_oom", "disable_panic_handler", "disable_allocator", "sgx"]
 [dependencies.sgx-runtime]
 default-features = false
 git = "https://github.com/scs/sgx-runtime"
-#tag = "v2.0.0-alpha.6"
+tag = "v2.0.0-alpha.7"
 optional = true
 
 [dependencies.sc-keystore]

--- a/substratee-node-primitives/Cargo.toml
+++ b/substratee-node-primitives/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "substratee-node-primitives"
-version = "0.6.3-sub2.0.0-alpha.7"
+version = "0.6.4-sub2.0.0-alpha.7"
 authors = ["clangenbacher <christian.langenbacher@scs.ch>"]
 edition = "2018"
 

--- a/substratee-node-primitives/Cargo.toml
+++ b/substratee-node-primitives/Cargo.toml
@@ -16,9 +16,9 @@ features = ["untrusted_fs","net","backtrace"]
 rev = "v1.1.2"
 optional = true
 
-[dependencies.my-node-runtime]
+[dependencies.substratee-node-runtime]
 git = "https://github.com/scs/substraTEE-node"
-tag = "v0.6.3-sub2.0.0-alpha.7"
+tag = "v0.6.5-sub2.0.0-alpha.7"
 package = "substratee-node-runtime"
 optional = true
 default-features = false
@@ -40,7 +40,7 @@ optional = true
 [features]
 default = ['std']
 std = [ 'substrate-api-client',
-        'my-node-runtime',
+        'substratee-node-runtime',
         'sp-core/std',
         'sp-runtime',
         'base58',

--- a/substratee-node-primitives/src/lib.rs
+++ b/substratee-node-primitives/src/lib.rs
@@ -23,12 +23,12 @@ pub type CallWorkerFn = ([u8; 2], Request);
 
 #[cfg(feature = "std")]
 pub mod calls {
-    pub use my_node_runtime::{
+    use sp_core::crypto::Pair;
+    use sp_runtime::MultiSignature;
+    pub use substratee_node_runtime::{
         substratee_registry::{Enclave, ShardIdentifier},
         AccountId,
     };
-    use sp_core::crypto::Pair;
-    use sp_runtime::MultiSignature;
 
     pub fn get_worker_info<P: Pair>(
         api: &substrate_api_client::Api<P>,

--- a/worker/Cargo.toml
+++ b/worker/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "substratee-worker"
-version = "0.6.3-sub2.0.0-alpha.7"
+version = "0.6.4-sub2.0.0-alpha.7"
 authors = ["Supercomputing Systems AG <info@scs.ch>"]
 build = "build.rs"
 edition = "2018"

--- a/worker/Cargo.toml
+++ b/worker/Cargo.toml
@@ -46,7 +46,7 @@ path = "worker-api"
 
 [dependencies.substratee-node-runtime]
 git = "https://github.com/scs/substraTEE-node"
-tag = "v0.6.3-sub2.0.0-alpha.7"
+tag = "v0.6.5-sub2.0.0-alpha.7"
 package = "substratee-node-runtime"
 
 [dependencies.sp-finality-grandpa]

--- a/worker/worker-api/Cargo.toml
+++ b/worker/worker-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "substratee-worker-api"
-version = "0.6.3-sub2.0.0-alpha.7"
+version = "0.6.4-sub2.0.0-alpha.7"
 authors = ["Supercomputing Systems AG <info@scs.ch>"]
 edition = "2018"
 


### PR DESCRIPTION
* bump substratee-node
* bump substrate-api-client
* tag sgx-runtime (was untagged before)
* bump version: 0.6.4-sub2.0.0-alpha.7