### PR TITLE
mitigate-involuntary-replay-attack-in-unshield

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1183,7 +1183,7 @@ dependencies = [
 [[package]]
 name = "ias-verify"
 version = "0.1.0"
-source = "git+https://github.com/scs/pallet-substratee-registry.git?tag=v0.6.7-sub2.0.0-alpha.7#c4bcb69975b96a52a68b95a852d3c4a02c84c241"
+source = "git+https://github.com/scs/pallet-substratee-registry.git?tag=v0.6.8-sub2.0.0-alpha.7#9adb121943960f983e6261d64c74f7d4bba37918"
 dependencies = [
  "base64",
  "chrono",
@@ -1968,8 +1968,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-substratee-registry"
-version = "0.6.7-sub2.0.0-alpha.7"
-source = "git+https://github.com/scs/pallet-substratee-registry.git?tag=v0.6.7-sub2.0.0-alpha.7#c4bcb69975b96a52a68b95a852d3c4a02c84c241"
+version = "0.6.8-sub2.0.0-alpha.7"
+source = "git+https://github.com/scs/pallet-substratee-registry.git?tag=v0.6.8-sub2.0.0-alpha.7#9adb121943960f983e6261d64c74f7d4bba37918"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3818,8 +3818,8 @@ dependencies = [
 
 [[package]]
 name = "substratee-node-runtime"
-version = "0.6.5-sub2.0.0-alpha.7"
-source = "git+https://github.com/scs/substraTEE-node?tag=v0.6.5-sub2.0.0-alpha.7#6b0ef0b840c34e0a9beb418125a6dc7904a7862c"
+version = "0.6.6-sub2.0.0-alpha.7"
+source = "git+https://github.com/scs/substraTEE-node?tag=v0.6.6-sub2.0.0-alpha.7#53c2c0330ebf55b869f2fcd106490cff9a466417"
 dependencies = [
  "frame-executive",
  "frame-support",

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -53,7 +53,7 @@ default-features=false
 
 [dependencies.substratee-node-runtime]
 git = "https://github.com/scs/substraTEE-node"
-tag = "v0.6.5-sub2.0.0-alpha.7"
+tag = "v0.6.6-sub2.0.0-alpha.7"
 package = "substratee-node-runtime"
 
 [dependencies.substratee-stf]

--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -515,9 +515,7 @@ fn send_request(matches: &ArgMatches<'_>, call: TrustedCallSigned) -> Option<Vec
     decoder
         .register_type_size::<Hash>("ShardIdentifier")
         .unwrap();
-    decoder
-        .register_type_size::<(Hash, Vec<u8>)>("Request")
-        .unwrap();
+    decoder.register_type_size::<Hash>("H256").unwrap();
 
     loop {
         let ret: CallConfirmedArgs = _chain_api
@@ -529,7 +527,7 @@ fn send_request(matches: &ArgMatches<'_>, call: TrustedCallSigned) -> Option<Vec
             )
             .unwrap()
             .unwrap();
-        let expected = blake2_256(&call_encoded);
+        let expected = H256::from(blake2_256(&call_encoded));
         info!("callConfirmed event received");
         debug!("Expected stf call Hash: {:?}", expected);
         debug!("Confirmed stf call Hash: {:?}", ret.payload);
@@ -543,7 +541,7 @@ fn send_request(matches: &ArgMatches<'_>, call: TrustedCallSigned) -> Option<Vec
 #[derive(Decode)]
 struct CallConfirmedArgs {
     signer: AccountId,
-    payload: Vec<u8>,
+    payload: H256,
 }
 
 fn listen(matches: &ArgMatches<'_>) {
@@ -619,7 +617,7 @@ fn listen(matches: &ArgMatches<'_>) {
 }
 
 // subscribes to he substratee_registry events of type CallConfirmed
-pub fn subscribe_to_call_confirmed<P: Pair>(api: Api<P>) -> Vec<u8>
+pub fn subscribe_to_call_confirmed<P: Pair>(api: Api<P>) -> H256
 where
     MultiSignature: From<P::Signature>,
 {
@@ -649,7 +647,7 @@ where
                     ) = &pe
                     {
                         println!("[+] Received confirm call from {}", sender);
-                        return payload.to_vec();
+                        return payload.clone().to_owned();
                     } else {
                         debug!(
                             "received unknown event from SubstraTeeRegistry: {:?}",

--- a/substratee-node-primitives/Cargo.toml
+++ b/substratee-node-primitives/Cargo.toml
@@ -18,7 +18,7 @@ optional = true
 
 [dependencies.substratee-node-runtime]
 git = "https://github.com/scs/substraTEE-node"
-tag = "v0.6.5-sub2.0.0-alpha.7"
+tag = "v0.6.6-sub2.0.0-alpha.7"
 package = "substratee-node-runtime"
 optional = true
 default-features = false

--- a/substratee-node-primitives/src/lib.rs
+++ b/substratee-node-primitives/src/lib.rs
@@ -17,7 +17,7 @@ pub struct Request {
     pub cyphertext: Vec<u8>,
 }
 
-pub type SubstrateeConfirmCallFn = ([u8; 2], ShardIdentifier, Vec<u8>, Vec<u8>);
+pub type SubstrateeConfirmCallFn = ([u8; 2], ShardIdentifier, H256, Vec<u8>);
 pub type ShieldFundsFn = ([u8; 2], Vec<u8>, u128, ShardIdentifier);
 pub type CallWorkerFn = ([u8; 2], Request);
 

--- a/worker/Cargo.toml
+++ b/worker/Cargo.toml
@@ -46,7 +46,7 @@ path = "worker-api"
 
 [dependencies.substratee-node-runtime]
 git = "https://github.com/scs/substraTEE-node"
-tag = "v0.6.5-sub2.0.0-alpha.7"
+tag = "v0.6.6-sub2.0.0-alpha.7"
 package = "substratee-node-runtime"
 
 [dependencies.sp-finality-grandpa]

--- a/worker/src/main.rs
+++ b/worker/src/main.rs
@@ -398,6 +398,13 @@ fn print_events(events: Events, _sender: Sender<String>) {
                         debug!("    For:    {:?}", incognito_account);
                         println!();
                     }
+                    substratee_node_runtime::substratee_registry::RawEvent::UnshieldedFunds(
+                        incognito_account,
+                    ) => {
+                        println!("[+] Received UnshieldedFunds event");
+                        debug!("    For:    {:?}", incognito_account);
+                        println!();
+                    }
                     _ => {
                         info!("Ignoring unsupported substratee_registry event");
                     }


### PR DESCRIPTION
* bump node: v0.6.6-sub2.0.0-alpha.7
* include hash of trusted_call_signed in shield_funds extrinsic
* change call_hash to H256