### PR TITLE
fix running multiple workers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3771,7 +3771,7 @@ checksum = "d2a965994514ab35d3893e9260245f2947fd1981cdd4fffd2c6e6d1a9ce02e6a"
 
 [[package]]
 name = "substratee-client"
-version = "0.6.4-sub2.0.0-alpha.7"
+version = "0.6.5-sub2.0.0-alpha.7"
 dependencies = [
  "base58",
  "blake2-rfc",
@@ -3803,7 +3803,7 @@ dependencies = [
 
 [[package]]
 name = "substratee-node-primitives"
-version = "0.6.4-sub2.0.0-alpha.7"
+version = "0.6.5-sub2.0.0-alpha.7"
 dependencies = [
  "base58",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3851,7 +3851,7 @@ dependencies = [
 
 [[package]]
 name = "substratee-stf"
-version = "0.6.4-sub2.0.0-alpha.7"
+version = "0.6.5-sub2.0.0-alpha.7"
 dependencies = [
  "base58",
  "clap",
@@ -3876,7 +3876,7 @@ dependencies = [
 
 [[package]]
 name = "substratee-worker"
-version = "0.6.4-sub2.0.0-alpha.7"
+version = "0.6.5-sub2.0.0-alpha.7"
 dependencies = [
  "base58",
  "cid",
@@ -3915,7 +3915,7 @@ dependencies = [
 
 [[package]]
 name = "substratee-worker-api"
-version = "0.6.4-sub2.0.0-alpha.7"
+version = "0.6.5-sub2.0.0-alpha.7"
 dependencies = [
  "hex 0.4.2",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "substratee-client"
-version = "0.6.4-sub2.0.0-alpha.7"
+version = "0.6.5-sub2.0.0-alpha.7"
 authors = ["Supercomputing Systems AG <info@scs.ch>"]
 edition = "2018"
 

--- a/enclave/Cargo.lock
+++ b/enclave/Cargo.lock
@@ -172,7 +172,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "chain-relay"
-version = "0.6.4-sub2.0.0-alpha.7"
+version = "0.6.5-sub2.0.0-alpha.7"
 dependencies = [
  "derive_more 0.99.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "finality-grandpa 0.11.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2068,7 +2068,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "substratee-node-primitives"
-version = "0.6.4-sub2.0.0-alpha.7"
+version = "0.6.5-sub2.0.0-alpha.7"
 dependencies = [
  "parity-scale-codec 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "primitive-types 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2078,7 +2078,7 @@ dependencies = [
 
 [[package]]
 name = "substratee-stf"
-version = "0.6.4-sub2.0.0-alpha.7"
+version = "0.6.5-sub2.0.0-alpha.7"
 dependencies = [
  "derive_more 0.99.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.7.1 (git+https://github.com/mesalock-linux/env_logger-sgx)",
@@ -2097,12 +2097,12 @@ dependencies = [
 
 [[package]]
 name = "substratee-worker-enclave"
-version = "0.6.4-sub2.0.0-alpha.7"
+version = "0.6.5-sub2.0.0-alpha.7"
 dependencies = [
  "aes 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "base64 0.10.1 (git+https://github.com/mesalock-linux/rust-base64-sgx)",
  "bit-vec 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "chain-relay 0.6.4-sub2.0.0-alpha.7",
+ "chain-relay 0.6.5-sub2.0.0-alpha.7",
  "chrono 0.4.11 (git+https://github.com/mesalock-linux/chrono-sgx)",
  "env_logger 0.7.1 (git+https://github.com/mesalock-linux/env_logger-sgx)",
  "httparse 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2136,8 +2136,8 @@ dependencies = [
  "sp-runtime 2.0.0-alpha.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "sp-std 2.0.0-alpha.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "substrate-api-client 0.4.6-sub2.0.0-alpha.7 (git+https://github.com/scs/substrate-api-client?tag=v0.4.6-sub2.0.0-alpha.7)",
- "substratee-node-primitives 0.6.4-sub2.0.0-alpha.7",
- "substratee-stf 0.6.4-sub2.0.0-alpha.7",
+ "substratee-node-primitives 0.6.5-sub2.0.0-alpha.7",
+ "substratee-stf 0.6.5-sub2.0.0-alpha.7",
  "webpki 0.21.2 (git+https://github.com/mesalock-linux/webpki?branch=mesalock_sgx)",
  "webpki-roots 0.19.0 (git+https://github.com/mesalock-linux/webpki-roots?branch=mesalock_sgx)",
  "yasna 0.3.1 (git+https://github.com/mesalock-linux/yasna.rs-sgx?rev=sgx_1.1.2)",

--- a/enclave/Cargo.toml
+++ b/enclave/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "substratee-worker-enclave"
-version = "0.6.4-sub2.0.0-alpha.7"
+version = "0.6.5-sub2.0.0-alpha.7"
 authors = ["Supercomputing Systems AG <info@scs.ch>"]
 edition = "2018"
 

--- a/enclave/Enclave.edl
+++ b/enclave/Enclave.edl
@@ -71,11 +71,7 @@ enclave {
 		public sgx_status_t dump_ra_to_disk();
 
 		public sgx_status_t run_key_provisioning_server(int fd,sgx_quote_sign_type_t quote_type);
-        public sgx_status_t request_key_provisioning(
-            int fd,
-            sgx_quote_sign_type_t quote_type,
-            [in, size=shard_size] uint8_t* shard, size_t shard_size
-        );
+        public sgx_status_t request_key_provisioning(int fd, sgx_quote_sign_type_t quote_type);
 
 		public size_t test_main_entrance();
 	};

--- a/enclave/Enclave.edl
+++ b/enclave/Enclave.edl
@@ -71,7 +71,11 @@ enclave {
 		public sgx_status_t dump_ra_to_disk();
 
 		public sgx_status_t run_key_provisioning_server(int fd,sgx_quote_sign_type_t quote_type);
-        public sgx_status_t request_key_provisioning(int fd,sgx_quote_sign_type_t quote_type);
+        public sgx_status_t request_key_provisioning(
+            int fd,
+            sgx_quote_sign_type_t quote_type,
+            [in, size=shard_size] uint8_t* shard, size_t shard_size
+        );
 
 		public size_t test_main_entrance();
 	};

--- a/enclave/chain_relay/Cargo.toml
+++ b/enclave/chain_relay/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chain-relay"
-version = "0.6.4-sub2.0.0-alpha.7"
+version = "0.6.5-sub2.0.0-alpha.7"
 authors = ["Supercomputing Systems AG <info@scs.ch>"]
 edition = "2018"
 

--- a/enclave/src/cert.rs
+++ b/enclave/src/cert.rs
@@ -402,10 +402,12 @@ fn verify_attn_report(report_raw: &[u8], pub_k: Vec<u8>) -> Result<(), sgx_statu
         // TODO: lack security check here
         let sgx_quote: sgx_quote_t = unsafe { ptr::read(quote.as_ptr() as *const _) };
 
-        let ti: sgx_target_info_t = sgx_target_info_t::default();
-
-        if sgx_quote.report_body.mr_enclave.m != ti.mr_enclave.m {
-            error!("mr_enclave is not equal to self");
+        let ti = crate::attestation::get_mrenclave_of_self().sgx_error()?;
+        if sgx_quote.report_body.mr_enclave.m != ti.m {
+            error!(
+                "mr_enclave is not equal to self {:?} != {:?}",
+                sgx_quote.report_body.mr_enclave.m, ti.m
+            );
             return Err(sgx_status_t::SGX_ERROR_UNEXPECTED);
         }
 

--- a/enclave/src/tls_ra.rs
+++ b/enclave/src/tls_ra.rs
@@ -173,7 +173,7 @@ fn send_files(
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn request_key_provisioning(
+pub extern "C" fn request_key_provisioning(
     socket_fd: c_int,
     sign_type: sgx_quote_sign_type_t,
 ) -> sgx_status_t {

--- a/stf/Cargo.toml
+++ b/stf/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "substratee-stf"
-version = "0.6.4-sub2.0.0-alpha.7"
+version = "0.6.5-sub2.0.0-alpha.7"
 authors = ["Supercomputing Systems AG <info@scs.ch>"]
 edition = "2018"
 

--- a/substratee-node-primitives/Cargo.toml
+++ b/substratee-node-primitives/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "substratee-node-primitives"
-version = "0.6.4-sub2.0.0-alpha.7"
+version = "0.6.5-sub2.0.0-alpha.7"
 authors = ["clangenbacher <christian.langenbacher@scs.ch>"]
 edition = "2018"
 

--- a/worker/Cargo.toml
+++ b/worker/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "substratee-worker"
-version = "0.6.4-sub2.0.0-alpha.7"
+version = "0.6.5-sub2.0.0-alpha.7"
 authors = ["Supercomputing Systems AG <info@scs.ch>"]
 build = "build.rs"
 edition = "2018"

--- a/worker/src/cli.yml
+++ b/worker/src/cli.yml
@@ -90,6 +90,10 @@ subcommands:
                     help: Run integration tests
                     takes_value: false
                 - provisioning-server:
+                    long: provisioning-server
                     help: Run TEE server for MU-RA key provisioning
+                    takes_value: false
                 - provisioning-client:
+                    long: provisioning-client
                     help: Run TEE client for MU-RA key provisioning
+                    takes_value: false

--- a/worker/src/enclave/tls_ra.rs
+++ b/worker/src/enclave/tls_ra.rs
@@ -19,9 +19,7 @@ use std::os::unix::io::AsRawFd;
 
 use sgx_types::*;
 
-use codec::Encode;
 use log::*;
-use substratee_node_primitives::ShardIdentifier;
 
 extern "C" {
     fn run_key_provisioning_server(
@@ -35,8 +33,6 @@ extern "C" {
         retval: *mut sgx_status_t,
         socket_fd: c_int,
         sign_type: sgx_quote_sign_type_t,
-        shard: *const u8,
-        shard_size: usize,
     ) -> sgx_status_t;
 }
 
@@ -76,24 +72,13 @@ pub fn enclave_request_key_provisioning(
     eid: sgx_enclave_id_t,
     sign_type: sgx_quote_sign_type_t,
     addr: &str,
-    shard: ShardIdentifier,
 ) -> SgxResult<()> {
     info!("[MU-RA-Client] Requesting key provisioning from {}", addr);
     let socket = TcpStream::connect(addr).unwrap();
     let mut status = sgx_status_t::SGX_SUCCESS;
 
-    warn!("Shard len: {:?}", shard.encode().len());
-
-    let result = unsafe {
-        request_key_provisioning(
-            eid,
-            &mut status,
-            socket.as_raw_fd(),
-            sign_type,
-            shard.encode().as_ptr(),
-            shard.encode().len(),
-        )
-    };
+    let result =
+        unsafe { request_key_provisioning(eid, &mut status, socket.as_raw_fd(), sign_type) };
     if status != sgx_status_t::SGX_SUCCESS {
         return Err(status);
     }

--- a/worker/src/main.rs
+++ b/worker/src/main.rs
@@ -18,6 +18,7 @@ use std::fs::{self, File};
 use std::io::stdin;
 use std::io::Write;
 use std::path::Path;
+use std::slice;
 use std::str;
 use std::sync::mpsc::{channel, Sender};
 use std::thread;
@@ -47,8 +48,7 @@ use enclave::api::{
 };
 use enclave::tls_ra::{enclave_request_key_provisioning, enclave_run_key_provisioning_server};
 use sp_finality_grandpa::{AuthorityList, VersionedAuthorityList, GRANDPA_AUTHORITIES_KEY};
-use std::slice;
-use substratee_node_primitives::calls::{get_worker_for_shard, get_worker_info};
+use substratee_node_primitives::calls::get_first_worker_that_is_not_equal_to_self;
 use substratee_worker_api::Api as WorkerApi;
 use ws_server::start_ws_server;
 
@@ -262,33 +262,24 @@ fn worker(node_url: &str, w_ip: &str, w_port: &str, mu_ra_port: &str, shard: &Sh
     println!("[<] Extrinsic got finalized. Hash: {:?}\n", tx_hash);
 
     // browse enclave registry
-    match get_worker_for_shard(&api, shard) {
+    match get_first_worker_that_is_not_equal_to_self(&api, &tee_accountid) {
         Some(w) => {
-            let master_worker = get_worker_info(&api, w).unwrap();
-            if master_worker.pubkey == tee_accountid {
-                info!("the most recently active worker is myself");
-                ensure_shard_initialized(shard);
-            } else {
-                let _url = String::from_utf8_lossy(&master_worker.url[..]).to_string();
-                let _w_api = WorkerApi::new(_url.clone());
-                let _url_split: Vec<_> = _url.split(':').collect();
-                let mura_url = format!("{}:{}", _url_split[0], _w_api.get_mu_ra_port().unwrap());
+            let _url = String::from_utf8_lossy(&w.url[..]).to_string();
+            let _w_api = WorkerApi::new(_url.clone());
+            let _url_split: Vec<_> = _url.split(':').collect();
+            let mura_url = format!("{}:{}", _url_split[0], _w_api.get_mu_ra_port().unwrap());
 
-                info!("Requesting key provisioning from worker at {}", mura_url);
-                enclave_request_key_provisioning(
-                    eid,
-                    sgx_quote_sign_type_t::SGX_UNLINKABLE_SIGNATURE,
-                    &mura_url,
-                )
-                .unwrap();
-                debug!("key provisioning successfully performed");
-            }
+            info!("Requesting key provisioning from worker at {}", mura_url);
+            enclave_request_key_provisioning(
+                eid,
+                sgx_quote_sign_type_t::SGX_UNLINKABLE_SIGNATURE,
+                &mura_url,
+            )
+            .unwrap();
+            debug!("key provisioning successfully performed");
         }
         None => {
-            info!(
-                "no worker has ever published a state update for shard {}",
-                shard.encode().to_base58()
-            );
+            info!("there are no other workers");
             ensure_shard_initialized(shard);
         }
     }

--- a/worker/src/main.rs
+++ b/worker/src/main.rs
@@ -186,8 +186,22 @@ fn main() {
             println!("[+] Done!");
             enclave.destroy();
         } else if _matches.is_present("provisioning-client") {
-            println!("*** Running Enclave MU-RA TLS server\n");
+            println!("*** Running Enclave MU-RA TLS client\n");
             let enclave = enclave_init().unwrap();
+            let shard = match _matches.values_of("shard") {
+                Some(values) => values
+                    .map(|shard| {
+                        shard
+                            .from_base58()
+                            .unwrap_or_else(|_| panic!("shard must be hex encoded"))
+                    })
+                    .map(|s| ShardIdentifier::from_slice(s.as_slice()))
+                    .collect(),
+                _ => vec![ShardIdentifier::from_slice(
+                    &enclave_mrenclave(enclave.geteid()).unwrap(),
+                )],
+            };
+
             enclave_request_key_provisioning(
                 enclave.geteid(),
                 sgx_quote_sign_type_t::SGX_UNLINKABLE_SIGNATURE,

--- a/worker/src/main.rs
+++ b/worker/src/main.rs
@@ -206,6 +206,7 @@ fn main() {
                 enclave.geteid(),
                 sgx_quote_sign_type_t::SGX_UNLINKABLE_SIGNATURE,
                 &format!("localhost:{}", mu_ra_port),
+                shard[0],
             )
             .unwrap();
             println!("[+] Done!");
@@ -293,6 +294,7 @@ fn worker(node_url: &str, w_ip: &str, w_port: &str, mu_ra_port: &str, shard: &Sh
                     eid,
                     sgx_quote_sign_type_t::SGX_UNLINKABLE_SIGNATURE,
                     &mura_url,
+                    *shard,
                 )
                 .unwrap();
                 debug!("key provisioning successfully performed");

--- a/worker/src/main.rs
+++ b/worker/src/main.rs
@@ -209,6 +209,7 @@ fn worker(node_url: &str, w_ip: &str, w_port: &str, mu_ra_port: &str, shard: &Sh
     // ------------------------------------------------------------------------
     // check for required files
     check_files();
+    ensure_shard_initialized(shard);
     // ------------------------------------------------------------------------
     // initialize the enclave
     #[cfg(feature = "production")]
@@ -280,7 +281,6 @@ fn worker(node_url: &str, w_ip: &str, w_port: &str, mu_ra_port: &str, shard: &Sh
         }
         None => {
             info!("there are no other workers");
-            ensure_shard_initialized(shard);
         }
     }
 

--- a/worker/src/main.rs
+++ b/worker/src/main.rs
@@ -251,7 +251,6 @@ fn worker(node_url: &str, w_ip: &str, w_port: &str, mu_ra_port: &str, shard: &Sh
     info!("Enclave nonce = {:?}", nonce);
 
     let uxt = enclave_perform_ra(eid, genesis_hash, nonce, w_url.as_bytes().to_vec()).unwrap();
-    let mut latest_head = init_chain_relay(eid, &api);
 
     let ue = UncheckedExtrinsic::decode(&mut uxt.as_slice()).unwrap();
     let mut _xthex = hex::encode(ue.encode());
@@ -293,6 +292,8 @@ fn worker(node_url: &str, w_ip: &str, w_port: &str, mu_ra_port: &str, shard: &Sh
             ensure_shard_initialized(shard);
         }
     }
+
+    let mut latest_head = init_chain_relay(eid, &api);
 
     // ------------------------------------------------------------------------
     // subscribe to events and react on firing

--- a/worker/src/main.rs
+++ b/worker/src/main.rs
@@ -188,25 +188,10 @@ fn main() {
         } else if _matches.is_present("provisioning-client") {
             println!("*** Running Enclave MU-RA TLS client\n");
             let enclave = enclave_init().unwrap();
-            let shard = match _matches.values_of("shard") {
-                Some(values) => values
-                    .map(|shard| {
-                        shard
-                            .from_base58()
-                            .unwrap_or_else(|_| panic!("shard must be hex encoded"))
-                    })
-                    .map(|s| ShardIdentifier::from_slice(s.as_slice()))
-                    .collect(),
-                _ => vec![ShardIdentifier::from_slice(
-                    &enclave_mrenclave(enclave.geteid()).unwrap(),
-                )],
-            };
-
             enclave_request_key_provisioning(
                 enclave.geteid(),
                 sgx_quote_sign_type_t::SGX_UNLINKABLE_SIGNATURE,
                 &format!("localhost:{}", mu_ra_port),
-                shard[0],
             )
             .unwrap();
             println!("[+] Done!");
@@ -294,7 +279,6 @@ fn worker(node_url: &str, w_ip: &str, w_port: &str, mu_ra_port: &str, shard: &Sh
                     eid,
                     sgx_quote_sign_type_t::SGX_UNLINKABLE_SIGNATURE,
                     &mura_url,
-                    *shard,
                 )
                 .unwrap();
                 debug!("key provisioning successfully performed");

--- a/worker/worker-api/Cargo.toml
+++ b/worker/worker-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "substratee-worker-api"
-version = "0.6.4-sub2.0.0-alpha.7"
+version = "0.6.5-sub2.0.0-alpha.7"
 authors = ["Supercomputing Systems AG <info@scs.ch>"]
 edition = "2018"
 


### PR DESCRIPTION
This pull request fixes the mutual remove attestation, which was broken with to the introduction of shards. The enclave state is no longer provisioned in mutual remote attestation as each enclave can reproduce past worker requests upon block inclusion from the chain relay.

**mutual remote attestation**
* fix mr_enclave check, which possibly never worked
* remove state provisioning as every enclave can now calculate its state from genesis

**worker**
* use `get_first_worker_not_equal_to_self` instead of `get_worker_for_shard` to request key provisioning as no state is exchanged anymore in mura. Closes #146 
* fix cli for provisioning tests, which possibly never worked since the cli revamp long ago.