### PR TITLE
on block storage updates for every shard

### DIFF
--- a/enclave/src/lib.rs
+++ b/enclave/src/lib.rs
@@ -325,7 +325,7 @@ pub unsafe extern "C" fn sync_chain_relay(
 
         match scan_block_for_relevant_xt(&signed_block.block, node_url) {
             Ok(c) => calls.extend(c.into_iter()),
-            Err(e) => return e,
+            Err(_) => error!("Error executing relevant extrinsics"),
         };
 
         if update_states(signed_block.block.header, node_url).is_err() {

--- a/enclave/src/lib.rs
+++ b/enclave/src/lib.rs
@@ -328,7 +328,7 @@ pub unsafe extern "C" fn sync_chain_relay(
             Err(e) => return e,
         };
 
-        if let Err(_) = update_states(signed_block.block.header, node_url) {
+        if update_states(signed_block.block.header, node_url).is_err() {
             error!("Error performing state updates upon block import")
         }
     }
@@ -400,9 +400,10 @@ fn handle_shield_funds_xt(
         call, account_encrypted, amount, shard
     );
 
-    let mut state = match state::exists(&shard) {
-        true => state::load(&shard)?,
-        false => Stf::init_state(),
+    let mut state = if state::exists(&shard) {
+        state::load(&shard)?
+    } else {
+        Stf::init_state()
     };
 
     debug!("decrypt the call");
@@ -472,9 +473,10 @@ fn handle_call_worker_xt(
         return Ok(());
     }
 
-    let mut state = match state::exists(&shard) {
-        true => state::load(&shard)?,
-        false => Stf::init_state(),
+    let mut state = if state::exists(&shard) {
+        state::load(&shard)?
+    } else {
+        Stf::init_state()
     };
 
     debug!("Update STF storage!");

--- a/enclave/src/lib.rs
+++ b/enclave/src/lib.rs
@@ -328,6 +328,17 @@ pub unsafe extern "C" fn sync_chain_relay(
         Err(e) => return e,
     };
 
+    // debug!("Update STF storage upon block import!");
+    // let requests = Stf::storage_hashes_to_update_on_block()
+    //     .into_iter()
+    //     .map(|key| WorkerRequest::ChainStorage(key, Some(header.hash())))
+    //     .collect();
+    //
+    // let responses: Vec<WorkerResponse<Vec<u8>>> = worker_request(requests, node_url)?;
+    //
+    // let update_map = verify_worker_responses(responses, header)?;
+    // Stf::update_storage(&mut state, update_map);
+
     if let Err(_e) = stf_post_actions(validator, calls, xt_slice, *nonce) {
         return sgx_status_t::SGX_ERROR_UNEXPECTED;
     }

--- a/enclave/src/lib.rs
+++ b/enclave/src/lib.rs
@@ -400,7 +400,10 @@ fn handle_shield_funds_xt(
         call, account_encrypted, amount, shard
     );
 
-    let mut state = state::load(&shard)?;
+    let mut state = match state::exists(&shard) {
+        true => state::load(&shard)?,
+        false => Stf::init_state(),
+    };
 
     debug!("decrypt the call");
     let rsa_keypair = rsa3072::unseal_pair()?;
@@ -469,7 +472,10 @@ fn handle_call_worker_xt(
         return Ok(());
     }
 
-    let mut state = state::load(&shard)?;
+    let mut state = match state::exists(&shard) {
+        true => state::load(&shard)?,
+        false => Stf::init_state(),
+    };
 
     debug!("Update STF storage!");
     let requests = Stf::get_storage_hashes_to_update(&stf_call_signed)

--- a/enclave/src/state.rs
+++ b/enclave/src/state.rs
@@ -31,6 +31,7 @@ use base58::{FromBase58, ToBase58};
 use codec::{Decode, Encode};
 use sgx_externalities::SgxExternalitiesTrait;
 use sp_core::H256;
+use std::path::Path;
 use substratee_stf::{ShardIdentifier, State as StfState, Stf};
 
 pub fn load(shard: &ShardIdentifier) -> SgxResult<StfState> {
@@ -79,6 +80,16 @@ pub fn write(state: StfState, shard: &ShardIdentifier) -> SgxResult<H256> {
 
     io::write(&cyphertext, &state_path)?;
     Ok(state_hash.into())
+}
+
+pub fn exists(shard: &ShardIdentifier) -> bool {
+    Path::new(&format!(
+        "{}/{}/{}",
+        SHARDS_PATH,
+        shard.encode().to_base58(),
+        ENCRYPTED_STATE_FILE
+    ))
+    .exists()
 }
 
 fn read(path: &str) -> SgxResult<Vec<u8>> {

--- a/stf/src/sgx.rs
+++ b/stf/src/sgx.rs
@@ -69,7 +69,7 @@ impl Stf {
         ext
     }
 
-    pub fn update_storage(ext: &mut State, map_update: HashMap<Vec<u8>, Vec<u8>>) {
+    pub fn update_storage(ext: &mut State, map_update: &HashMap<Vec<u8>, Vec<u8>>) {
         ext.execute_with(|| {
             map_update
                 .iter()

--- a/stf/src/sgx.rs
+++ b/stf/src/sgx.rs
@@ -203,6 +203,13 @@ impl Stf {
         };
         key_hashes
     }
+
+    pub fn storage_hashes_to_update_on_block() -> Vec<Vec<u8>> {
+        // let key_hashes = Vec::new();
+        // key_hashes.push(storage_value_key("dummy", "dummy"));
+        // key_hashes
+        Vec::new()
+    }
 }
 
 // get the AccountInfo key where the nonce is stored

--- a/worker/src/main.rs
+++ b/worker/src/main.rs
@@ -209,7 +209,6 @@ fn worker(node_url: &str, w_ip: &str, w_port: &str, mu_ra_port: &str, shard: &Sh
     // ------------------------------------------------------------------------
     // check for required files
     check_files();
-    ensure_shard_initialized(shard);
     // ------------------------------------------------------------------------
     // initialize the enclave
     #[cfg(feature = "production")]
@@ -581,21 +580,6 @@ fn get_balance(api: &Api<sr25519::Pair>, who: &AccountId32) -> u128 {
     } else {
         0
     }
-}
-
-fn ensure_shard_initialized(shard: &ShardIdentifier) {
-    let shardenc = shard.encode().to_base58();
-    if !Path::new(&format!(
-        "{}/{}/{}",
-        constants::SHARDS_PATH,
-        &shardenc,
-        constants::ENCRYPTED_STATE_FILE
-    ))
-    .exists()
-    {
-        panic!("shard {} hasn't been initialized", shardenc);
-    }
-    debug!("state file is present for shard {}", shardenc);
 }
 
 pub fn check_files() {


### PR DESCRIPTION
the enclave does now perform a state update on every shard upon block import with the keys given by the newly introduced `STF::storage_hashes_to_update_on_block`

As of now the enclave creates a new shard if it does not exist already.

Every shard located in the `shards` directory is updated.