### PR TITLE
allow on chain read in get state

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3888,6 +3888,7 @@ dependencies = [
  "hex 0.3.2",
  "hyper",
  "ipfs-api",
+ "lazy_static",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "multihash",
  "pallet-balances",

--- a/enclave/Enclave.edl
+++ b/enclave/Enclave.edl
@@ -48,7 +48,6 @@ enclave {
         public sgx_status_t sync_chain_relay(
             [in, size=blocks_size] uint8_t* blocks, size_t blocks_size,
             [in] uint32_t* nonce,
-            [in, size=node_url_size] uint8_t* node_url, size_t node_url_size,
             [out, size=unchecked_extrinsic_size] uint8_t* unchecked_extrinsic, size_t unchecked_extrinsic_size
         );
 
@@ -110,7 +109,6 @@ enclave {
 
 		sgx_status_t ocall_worker_request(
 	        [in, size = req_size] uint8_t * request, uint32_t req_size,
-   	        [in, size = node_url_size] uint8_t * node_url, uint32_t node_url_size,
 	        [out, size = resp_size] uint8_t * response, uint32_t resp_size
 	    );
 	};

--- a/enclave/Enclave.edl
+++ b/enclave/Enclave.edl
@@ -63,7 +63,7 @@ enclave {
 		public sgx_status_t perform_ra(
 			[in, size=genesis_hash_size] uint8_t* genesis_hash, uint32_t genesis_hash_size,
 			[in] uint32_t* nonce,
-			[in, size=url_size] uint8_t* url, uint32_t url_size,
+			[in, size=w_url_size] uint8_t* w_url, uint32_t w_url_size,
 			[out, size=unchecked_extrinsic_size] uint8_t* unchecked_extrinsic, uint32_t unchecked_extrinsic_size
 		);
 

--- a/enclave/src/attestation.rs
+++ b/enclave/src/attestation.rs
@@ -609,8 +609,8 @@ pub unsafe extern "C" fn perform_ra(
     genesis_hash: *const u8,
     genesis_hash_size: u32,
     nonce: *const u32,
-    url: *const u8,
-    url_size: u32,
+    w_url: *const u8,
+    w_url_size: u32,
     unchecked_extrinsic: *mut u8,
     unchecked_extrinsic_size: u32,
 ) -> sgx_status_t {
@@ -625,7 +625,7 @@ pub unsafe extern "C" fn perform_ra(
     info!("    [Enclave] Compose extrinsic");
     let genesis_hash_slice = slice::from_raw_parts(genesis_hash, genesis_hash_size as usize);
     //let mut nonce_slice     = slice::from_raw_parts(nonce, nonce_size as usize);
-    let url_slice = slice::from_raw_parts(url, url_size as usize);
+    let url_slice = slice::from_raw_parts(w_url, w_url_size as usize);
     let extrinsic_slice =
         slice::from_raw_parts_mut(unchecked_extrinsic, unchecked_extrinsic_size as usize);
     let signer = match ed25519::unseal_pair() {

--- a/enclave/src/lib.rs
+++ b/enclave/src/lib.rs
@@ -286,13 +286,10 @@ pub unsafe extern "C" fn sync_chain_relay(
     blocks: *const u8,
     blocks_size: usize,
     nonce: *const u32,
-    node_url: *const u8,
-    node_url_size: usize,
     unchecked_extrinsic: *mut u8,
     unchecked_extrinsic_size: usize,
 ) -> sgx_status_t {
     info!("Syncing chain relay!");
-    let node_url = slice::from_raw_parts(node_url, node_url_size as usize);
     let mut blocks_slice = slice::from_raw_parts(blocks, blocks_size);
     let xt_slice = slice::from_raw_parts_mut(unchecked_extrinsic, unchecked_extrinsic_size);
 
@@ -323,12 +320,12 @@ pub unsafe extern "C" fn sync_chain_relay(
             return sgx_status_t::SGX_ERROR_UNEXPECTED;
         }
 
-        match scan_block_for_relevant_xt(&signed_block.block, node_url) {
+        match scan_block_for_relevant_xt(&signed_block.block) {
             Ok(c) => calls.extend(c.into_iter()),
             Err(_) => error!("Error executing relevant extrinsics"),
         };
 
-        if update_states(signed_block.block.header, node_url).is_err() {
+        if update_states(signed_block.block.header).is_err() {
             error!("Error performing state updates upon block import")
         }
     }
@@ -340,7 +337,7 @@ pub unsafe extern "C" fn sync_chain_relay(
     sgx_status_t::SGX_SUCCESS
 }
 
-pub fn update_states(header: Header, node_url: &[u8]) -> SgxResult<()> {
+pub fn update_states(header: Header) -> SgxResult<()> {
     debug!("Update STF storage upon block import!");
     let requests: Vec<WorkerRequest> = Stf::storage_hashes_to_update_on_block()
         .into_iter()
@@ -351,7 +348,7 @@ pub fn update_states(header: Header, node_url: &[u8]) -> SgxResult<()> {
         return Ok(());
     }
 
-    let responses: Vec<WorkerResponse<Vec<u8>>> = worker_request(requests, node_url)?;
+    let responses: Vec<WorkerResponse<Vec<u8>>> = worker_request(requests)?;
     let update_map = verify_worker_responses(responses, header)?;
 
     let shards = state::list_shards()?;
@@ -365,7 +362,7 @@ pub fn update_states(header: Header, node_url: &[u8]) -> SgxResult<()> {
 }
 
 /// Scans blocks for extrinsics that ask the enclave to execute some actions.
-pub fn scan_block_for_relevant_xt(block: &Block, node_url: &[u8]) -> SgxResult<Vec<OpaqueCall>> {
+pub fn scan_block_for_relevant_xt(block: &Block) -> SgxResult<Vec<OpaqueCall>> {
     debug!("Scanning blocks for relevant xt");
     let mut calls = Vec::<OpaqueCall>::new();
     for xt_opaque in block.extrinsics.iter() {
@@ -384,9 +381,7 @@ pub fn scan_block_for_relevant_xt(block: &Block, node_url: &[u8]) -> SgxResult<V
             UncheckedExtrinsicV4::<CallWorkerFn>::decode(&mut xt_opaque.0.encode().as_slice())
         {
             if xt.function.0 == [SUBSRATEE_REGISTRY_MODULE, CALL_WORKER] {
-                if let Err(e) =
-                    handle_call_worker_xt(&mut calls, xt, block.header.clone(), node_url)
-                {
+                if let Err(e) = handle_call_worker_xt(&mut calls, xt, block.header.clone()) {
                     error!("Error performing worker call: Error: {:?}", e);
                 }
             }
@@ -446,7 +441,6 @@ fn handle_call_worker_xt(
     calls: &mut Vec<OpaqueCall>,
     xt: UncheckedExtrinsicV4<CallWorkerFn>,
     header: Header,
-    node_url: &[u8],
 ) -> SgxResult<()> {
     let (call, request) = xt.function;
     let (shard, cyphertext) = (request.shard, request.cyphertext);
@@ -489,7 +483,7 @@ fn handle_call_worker_xt(
         .map(|key| WorkerRequest::ChainStorage(key, Some(header.hash())))
         .collect();
 
-    let responses: Vec<WorkerResponse<Vec<u8>>> = worker_request(requests, node_url)?;
+    let responses: Vec<WorkerResponse<Vec<u8>>> = worker_request(requests)?;
 
     let update_map = verify_worker_responses(responses, header)?;
 
@@ -569,8 +563,6 @@ extern "C" {
         ret_val: *mut sgx_status_t,
         request: *const u8,
         req_size: u32,
-        node_url: *const u8,
-        node_url_size: u32,
         response: *mut u8,
         resp_size: u32,
     ) -> sgx_status_t;
@@ -634,7 +626,6 @@ pub enum WorkerResponse<V: Encode + Decode> {
 
 fn worker_request<V: Encode + Decode>(
     req: Vec<WorkerRequest>,
-    node_url: &[u8],
 ) -> SgxResult<Vec<WorkerResponse<V>>> {
     let mut rt: sgx_status_t = sgx_status_t::SGX_ERROR_UNEXPECTED;
     let mut resp: Vec<u8> = vec![0; 4196];
@@ -644,8 +635,6 @@ fn worker_request<V: Encode + Decode>(
             &mut rt as *mut sgx_status_t,
             req.encode().as_ptr(),
             req.encode().len() as u32,
-            node_url.as_ptr(),
-            node_url.len() as u32,
             resp.as_mut_ptr(),
             resp.len() as u32,
         )
@@ -664,14 +653,13 @@ fn worker_request<V: Encode + Decode>(
 fn test_ocall_worker_request() {
     info!("testing ocall_worker_request. Hopefully substraTEE-node is running...");
     let mut requests = Vec::new();
-    let node_url = format!("ws://{}:{}", "127.0.0.1", "9991").into_bytes();
 
     requests.push(WorkerRequest::ChainStorage(
         storage_key("Balances", "TotalIssuance").0,
         None,
     ));
 
-    let mut resp: Vec<WorkerResponse<Vec<u8>>> = match worker_request(requests, node_url.as_ref()) {
+    let mut resp: Vec<WorkerResponse<Vec<u8>>> = match worker_request(requests) {
         Ok(response) => response,
         Err(e) => panic!("Worker response decode failed. Error: {:?}", e),
     };

--- a/enclave/src/lib.rs
+++ b/enclave/src/lib.rs
@@ -430,6 +430,7 @@ fn handle_shield_funds_xt(
     let mut state = if state::exists(&shard) {
         state::load(&shard)?
     } else {
+        state::init_shard(&shard)?;
         Stf::init_state()
     };
 
@@ -502,6 +503,7 @@ fn handle_call_worker_xt(
     let mut state = if state::exists(&shard) {
         state::load(&shard)?
     } else {
+        state::init_shard(&shard)?;
         Stf::init_state()
     };
 

--- a/enclave/src/lib.rs
+++ b/enclave/src/lib.rs
@@ -342,10 +342,14 @@ pub unsafe extern "C" fn sync_chain_relay(
 
 pub fn update_states(header: Header, node_url: &[u8]) -> SgxResult<()> {
     debug!("Update STF storage upon block import!");
-    let requests = Stf::storage_hashes_to_update_on_block()
+    let requests: Vec<WorkerRequest> = Stf::storage_hashes_to_update_on_block()
         .into_iter()
         .map(|key| WorkerRequest::ChainStorage(key, Some(header.hash())))
         .collect();
+
+    if requests.is_empty() {
+        return Ok(());
+    }
 
     let responses: Vec<WorkerResponse<Vec<u8>>> = worker_request(requests, node_url)?;
     let update_map = verify_worker_responses(responses, header)?;

--- a/enclave/src/state.rs
+++ b/enclave/src/state.rs
@@ -92,6 +92,10 @@ pub fn exists(shard: &ShardIdentifier) -> bool {
     .exists()
 }
 
+pub fn init_shard(shard: &ShardIdentifier) -> SgxResult<()> {
+    fs::create_dir_all(format!("{}/{}", SHARDS_PATH, shard.encode().to_base58())).sgx_error()
+}
+
 fn read(path: &str) -> SgxResult<Vec<u8>> {
     let mut bytes = match io::read(path) {
         Ok(vec) => match vec.len() {

--- a/stf/src/lib.rs
+++ b/stf/src/lib.rs
@@ -102,7 +102,7 @@ impl TrustedCall {
     }
 }
 
-#[derive(Encode, Decode, Clone)]
+#[derive(Encode, Decode, Clone, Debug)]
 #[allow(non_camel_case_types)]
 pub enum TrustedGetter {
     free_balance(AccountId),

--- a/stf/src/sgx.rs
+++ b/stf/src/sgx.rs
@@ -12,7 +12,7 @@ use sp_io::SgxExternalitiesTrait;
 use sp_runtime::traits::Dispatchable;
 
 use crate::{
-    AccountId, State, Stf, TrustedCall, TrustedCallSigned, TrustedGetter,
+    AccountId, State, Stf, TrustedCall, TrustedCallSigned, TrustedGetter, TrustedGetterSigned,
     SUBSRATEE_REGISTRY_MODULE, UNSHIELD,
 };
 use sp_core::blake2_256;
@@ -201,6 +201,14 @@ impl Stf {
             }
             TrustedCall::balance_shield(_, _) => debug!("No storage updates needed..."),
         };
+        key_hashes
+    }
+
+    pub fn get_storage_hashes_to_update_for_getter(getter: &TrustedGetterSigned) -> Vec<Vec<u8>> {
+        let key_hashes = Vec::new();
+        match getter.getter {
+            _ => info!("No storage updates needed for getter: {:?}", getter.getter), // dummy is currently not needed
+        }
         key_hashes
     }
 

--- a/stf/src/sgx.rs
+++ b/stf/src/sgx.rs
@@ -206,9 +206,7 @@ impl Stf {
 
     pub fn get_storage_hashes_to_update_for_getter(getter: &TrustedGetterSigned) -> Vec<Vec<u8>> {
         let key_hashes = Vec::new();
-        match getter.getter {
-            _ => info!("No storage updates needed for getter: {:?}", getter.getter), // dummy is currently not needed
-        }
+        info!("No storage updates needed for getter: {:?}", getter.getter); // dummy. Is currently not needed
         key_hashes
     }
 

--- a/worker/Cargo.toml
+++ b/worker/Cargo.toml
@@ -13,6 +13,7 @@ env_logger 				= "0.7"
 base58 			        = "0.1"
 rust-crypto 			= "0.2"
 clap 					= { version = "2.33", features = [ "yaml" ] }
+lazy_static             = "1.4.0"
 
 dirs 					= "1.0.2"
 serde 					= "1.0"

--- a/worker/src/enclave/api.rs
+++ b/worker/src/enclave/api.rs
@@ -63,8 +63,6 @@ extern "C" {
         blocks: *const u8,
         blocks_size: usize,
         nonce: *const u32,
-        node_url: *const u8,
-        url_size: usize,
         unchecked_extrinsic: *mut u8,
         unchecked_extrinsic_size: usize,
     ) -> sgx_status_t;
@@ -237,7 +235,6 @@ pub fn enclave_sync_chain_relay(
     eid: sgx_enclave_id_t,
     blocks: Vec<SignedBlock>,
     tee_nonce: u32,
-    node_url: &str,
 ) -> SgxResult<Vec<u8>> {
     let mut status = sgx_status_t::SGX_SUCCESS;
 
@@ -251,8 +248,6 @@ pub fn enclave_sync_chain_relay(
                 b.as_ptr(),
                 b.len(),
                 &tee_nonce,
-                node_url.as_ptr(),
-                node_url.len(),
                 unchecked_extrinsics.as_mut_ptr(),
                 EXTRINSIC_MAX_SIZE,
             )

--- a/worker/src/enclave/api.rs
+++ b/worker/src/enclave/api.rs
@@ -94,8 +94,8 @@ extern "C" {
         genesis_hash: *const u8,
         genesis_hash_size: u32,
         nonce: *const u32,
-        url: *const u8,
-        url_size: u32,
+        w_url: *const u8,
+        w_url_size: u32,
         unchecked_extrinsic: *mut u8,
         unchecked_extrinsic_size: u32,
     ) -> sgx_status_t;
@@ -361,7 +361,7 @@ pub fn enclave_perform_ra(
     eid: sgx_enclave_id_t,
     genesis_hash: Vec<u8>,
     nonce: u32,
-    url: Vec<u8>,
+    w_url: Vec<u8>,
 ) -> SgxResult<Vec<u8>> {
     let unchecked_extrinsic_size = EXTRINSIC_MAX_SIZE;
     let mut unchecked_extrinsic: Vec<u8> = vec![0u8; unchecked_extrinsic_size as usize];
@@ -373,8 +373,8 @@ pub fn enclave_perform_ra(
             genesis_hash.as_ptr(),
             genesis_hash.len() as u32,
             &nonce,
-            url.as_ptr(),
-            url.len() as u32,
+            w_url.as_ptr(),
+            w_url.len() as u32,
             unchecked_extrinsic.as_mut_ptr(),
             unchecked_extrinsic_size as u32,
         )


### PR DESCRIPTION
**worker**
* use `lazy_static` to get a global static reference to the node_url. With this, we no longer need to pass the url into the enclave.

**enclave/stf**
* perform on-chain storage updates in get_state if needed