### PR TITLE
Return block confirmations with ocall instead of ecall

### DIFF
--- a/enclave/Enclave.edl
+++ b/enclave/Enclave.edl
@@ -48,8 +48,7 @@ enclave {
 
         public sgx_status_t produce_blocks(
             [in, size=blocks_size] uint8_t* blocks, size_t blocks_size,
-            [in] uint32_t* nonce,
-            [out, size=unchecked_extrinsic_size] uint8_t* unchecked_extrinsic, size_t unchecked_extrinsic_size
+            [in] uint32_t* nonce
         );
 
 		public sgx_status_t get_rsa_encryption_pubkey(

--- a/enclave/src/lib.rs
+++ b/enclave/src/lib.rs
@@ -519,8 +519,8 @@ fn execute_top_pool_calls(latest_onchain_header: Header) -> SgxResult<(Vec<Opaqu
         let pool: Arc<&BPool> = Arc::new(pool_guard.deref());
         let author: Arc<Author<&BPool>> = Arc::new(Author::new(pool));
 
-        // get all shards that exist within top pool of worker
-        let shards: Vec<ShardIdentifier> = author.get_shards();
+        // get all shards 
+        let shards = state::list_shards()?;
 
         // Handle trusted getters
         let start_time = SystemTime::now()

--- a/enclave/src/rpc/author/mod.rs
+++ b/enclave/src/rpc/author/mod.rs
@@ -190,10 +190,11 @@ where
                 TrustedOperation::get(getter) => {
                     match getter {
                         Getter::trusted(trusted_getter_signed) => getters.push(trusted_getter_signed.clone()),
-                        _ => return Err(StateRpcError::PoolError(PoolError::UnknownTrustedOperation))
+                        _ => error!("Found invalid trusted getter in top pool")
                     }
                 },
-                _ => return Err(StateRpcError::PoolError(PoolError::UnknownTrustedOperation))
+                _ => { // might be emtpy?
+                }
             }
         }
 

--- a/enclave/src/rpc/author/mod.rs
+++ b/enclave/src/rpc/author/mod.rs
@@ -45,6 +45,7 @@ use client_error::Error as ClientError;
 pub mod hash;
 
 use crate::rsa3072;
+use crate::state;
 
 /// Substrate authoring RPC API
 pub trait AuthorApi<Hash, BlockHash> {
@@ -130,6 +131,14 @@ where
         ext: Vec<u8>,
         shard: ShardIdentifier,
     ) -> FutureResult<TxHash<P>, RpcError> {
+        // check if shard already exists
+        let shards = match state::list_shards() {
+            Ok(shards) => shards,
+            Err(_) => return Box::pin(ready(Err(ClientError::InvalidShard.into()))),
+        };
+        if !shards.contains(&shard) {
+            return Box::pin(ready(Err(ClientError::InvalidShard.into())));
+        }
         // decrypt call
         let rsa_keypair = rsa3072::unseal_pair().unwrap();
         let request_vec: Vec<u8> = match rsa3072::decrypt(&ext.as_slice(), &rsa_keypair) {
@@ -200,7 +209,7 @@ where
         bytes_or_hash: Vec<hash::TrustedOperationOrHash<TxHash<P>>>,
         shard: ShardIdentifier,
         inblock: bool,
-    ) -> Result<Vec<TxHash<P>>> {
+    ) -> Result<Vec<TxHash<P>>> {        
         let hashes = bytes_or_hash
             .into_iter()
             .map(|x| match x {
@@ -228,6 +237,14 @@ where
         ext: Vec<u8>,
         shard: ShardIdentifier,
     ) -> FutureResult<TxHash<P>, RpcError> {
+        // check if shard already exists
+        let shards = match state::list_shards() {
+            Ok(shards) => shards,
+            Err(_) => return Box::pin(ready(Err(ClientError::InvalidShard.into()))),
+        };
+        if !shards.contains(&shard) {
+            return Box::pin(ready(Err(ClientError::InvalidShard.into())));
+        }
         // decrypt call
         let rsa_keypair = rsa3072::unseal_pair().unwrap();
         let request_vec: Vec<u8> = match rsa3072::decrypt(&ext.as_slice(), &rsa_keypair) {

--- a/stf/src/sgx.rs
+++ b/stf/src/sgx.rs
@@ -76,6 +76,9 @@ impl Stf {
                 &storage_value_key("Balances", "ExistentialDeposit"),
                 &1u128.encode(),
             );
+            sp_io::storage::set(
+                &storage_value_key("System", "Number"),
+                &0.encode());
             //FIXME: for testing purpose only - maybe add feature?
             // for example: feature = endowtestaccounts
             let public = AccountId32::from(sp_core::ed25519::Pair::from_seed(b"12345678901234567890123456789012").public());
@@ -122,9 +125,11 @@ impl Stf {
                 if let Ok(number) = BlockNumber::decode(&mut infovec.as_slice()) {
                     Some(number)
                 } else {
+                    error!("Blocknumber decode error");
                     None
                 }
             } else {
+                error!("No Blocknumber in state?");
                 None
             }      
         })

--- a/worker/src/enclave/api.rs
+++ b/worker/src/enclave/api.rs
@@ -63,8 +63,6 @@ extern "C" {
         blocks: *const u8,
         blocks_size: usize,
         nonce: *const u32,
-        unchecked_extrinsic: *mut u8,
-        unchecked_extrinsic_size: usize,
     ) -> sgx_status_t;
 
     fn get_rsa_encryption_pubkey(
@@ -238,10 +236,8 @@ pub fn enclave_produce_blocks(
     eid: sgx_enclave_id_t,
     blocks_to_sync: Vec<SignedBlock>,
     tee_nonce: u32,
-) -> SgxResult<Vec<u8>> {
+) -> SgxResult<()> {
     let mut status = sgx_status_t::SGX_SUCCESS;
-
-    let mut produced_blocks: Vec<u8> = vec![0u8; EXTRINSIC_MAX_SIZE];
 
     let result = unsafe {
         blocks_to_sync.using_encoded(|b| {
@@ -251,8 +247,6 @@ pub fn enclave_produce_blocks(
                 b.as_ptr(),
                 b.len(),
                 &tee_nonce,
-                produced_blocks.as_mut_ptr(),
-                EXTRINSIC_MAX_SIZE,
             )
         })
     };
@@ -264,7 +258,7 @@ pub fn enclave_produce_blocks(
         return Err(result);
     }
 
-    Ok(produced_blocks)
+    Ok(())
 }
 
 pub fn enclave_signing_key(eid: sgx_enclave_id_t) -> SgxResult<ed25519::Public> {

--- a/worker/src/main.rs
+++ b/worker/src/main.rs
@@ -71,7 +71,7 @@ mod tests;
 const BLOCK_SYNC_BATCH_SIZE: u32 = 1000;
 const VERSION: &str = env!("CARGO_PKG_VERSION");
 /// start block production every ... ms
-const BLOCK_PRODUCTION_INTERVAL: u64 = 1000;
+const BLOCK_PRODUCTION_INTERVAL: u64 = 10000;
 
 fn main() {
     // Setup logging

--- a/worker/src/main.rs
+++ b/worker/src/main.rs
@@ -71,7 +71,7 @@ mod tests;
 const BLOCK_SYNC_BATCH_SIZE: u32 = 1000;
 const VERSION: &str = env!("CARGO_PKG_VERSION");
 /// start block production every ... ms
-const BLOCK_PRODUCTION_INTERVAL: u64 = 10000;
+const BLOCK_PRODUCTION_INTERVAL: u64 = 6000;
 
 fn main() {
     // Setup logging


### PR DESCRIPTION
only commit [1ec6a08](https://github.com/scs/substraTEE-worker/pull/220/commits/1ec6a088dd4aa6a97d5e3bafcb9176763ae75956) is new. The other commits have already been [merged](https://github.com/scs/substraTEE-worker/pull/217) and successfully reviewed.