### PR TITLE
Indirect block production

### DIFF
--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -524,7 +524,7 @@ fn encode_encrypt<E: Encode>(
 
 fn send_request(matches: &ArgMatches<'_>, call: TrustedCallSigned) -> Option<Vec<u8>> {
     let chain_api = get_chain_api(matches);
-    let (call_encoded, call_encrypted) = match encode_encrypt(matches, call) {
+    let (_, call_encrypted) = match encode_encrypt(matches, call) {
         Ok((encoded, encrypted)) => (encoded, encrypted),
         Err(msg) => {
             println!("[Error]: {}", msg);
@@ -554,7 +554,7 @@ fn send_request(matches: &ArgMatches<'_>, call: TrustedCallSigned) -> Option<Vec
     info!("stf call extrinsic sent. Hash: {:?}", tx_hash);
     info!("waiting for confirmation of stf call");
     let (events_in, events_out) = channel();
-    _chain_api.subscribe_events(events_in);
+    _chain_api.subscribe_events(events_in).unwrap();
 
     let mut decoder = EventsDecoder::try_from(_chain_api.metadata.clone()).unwrap();
     decoder

--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -566,7 +566,7 @@ fn send_request(matches: &ArgMatches<'_>, call: TrustedCallSigned) -> Option<Vec
         let ret: CallConfirmedArgs = _chain_api
             .wait_for_event::<CallConfirmedArgs>(
                 "SubstrateeRegistry",
-                "CallConfirmed",
+                "BlockConfirmed",
                 Some(decoder.clone()),
                 &events_out,
             )

--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -563,21 +563,17 @@ fn send_request(matches: &ArgMatches<'_>, call: TrustedCallSigned) -> Option<Vec
     decoder.register_type_size::<Hash>("H256").unwrap();
 
     loop {
-        let ret: CallConfirmedArgs = _chain_api
-            .wait_for_event::<CallConfirmedArgs>(
+        let ret: BlockConfirmedArgs = _chain_api
+            .wait_for_event::<BlockConfirmedArgs>(
                 "SubstrateeRegistry",
                 "BlockConfirmed",
                 Some(decoder.clone()),
                 &events_out,
             )
             .unwrap();
-        let expected = H256::from(blake2_256(&call_encoded));
-        info!("callConfirmed event received");
-        debug!("Expected stf call Hash: {:?}", expected);
-        debug!("Confirmed stf call Hash: {:?}", ret.payload);
-        if ret.payload == expected {
-            return Some(ret.payload.encode());
-        }
+        info!("BlockConfirmed event received");
+        debug!("Confirmed stf block Hash: {:?}", ret.payload);
+        return Some(ret.payload.encode());
     }
 }
 
@@ -675,7 +671,7 @@ fn send_direct_request(
 
 #[allow(dead_code)]
 #[derive(Decode)]
-struct CallConfirmedArgs {
+struct BlockConfirmedArgs {
     signer: AccountId,
     payload: H256,
 }

--- a/stf/src/lib.rs
+++ b/stf/src/lib.rs
@@ -46,11 +46,12 @@ pub type AuthorityId = <Signature as Verify>::Signer;
 pub type AccountId = AccountId32;
 pub type Hash = sp_core::H256;
 pub type BalanceTransferFn = ([u8; 2], AccountId, Compact<u128>);
-pub static BALANCE_MODULE: u8 = 4u8;
+//FIXME: Obsolete?
+/* pub static BALANCE_MODULE: u8 = 4u8;
 pub static BALANCE_TRANSFER: u8 = 0u8;
 pub static SUBSRATEE_REGISTRY_MODULE: u8 = 8u8;
 pub static UNSHIELD: u8 = 5u8;
-pub static CALL_CONFIRMED: u8 = 3u8;
+pub static CALL_CONFIRMED: u8 = 3u8; */
 
 pub type ShardIdentifier = H256;
 

--- a/stf/src/lib.rs
+++ b/stf/src/lib.rs
@@ -46,12 +46,12 @@ pub type AuthorityId = <Signature as Verify>::Signer;
 pub type AccountId = AccountId32;
 pub type Hash = sp_core::H256;
 pub type BalanceTransferFn = ([u8; 2], AccountId, Compact<u128>);
-//FIXME: Obsolete?
-/* pub static BALANCE_MODULE: u8 = 4u8;
-pub static BALANCE_TRANSFER: u8 = 0u8;
+//FIXME: Is this really necessary to define all variables three times?
+//pub static BALANCE_MODULE: u8 = 4u8;
+//pub static BALANCE_TRANSFER: u8 = 0u8;
 pub static SUBSRATEE_REGISTRY_MODULE: u8 = 8u8;
-pub static UNSHIELD: u8 = 5u8;
-pub static CALL_CONFIRMED: u8 = 3u8; */
+pub static UNSHIELD: u8 = 6u8;
+//pub static CALL_CONFIRMED: u8 = 3u8;
 
 pub type ShardIdentifier = H256;
 

--- a/worker/src/main.rs
+++ b/worker/src/main.rs
@@ -478,6 +478,14 @@ fn print_events(events: Events, _sender: Sender<String>) {
                         debug!("    From:    {:?}", sender);
                         debug!("    Payload: {:?}", hex::encode(payload));
                     }
+                    my_node_runtime::substratee_registry::RawEvent::BlockConfirmed(
+                        sender,
+                        payload,
+                    ) => {
+                        info!("[+] Received BlockConfirmed event");
+                        debug!("    From:    {:?}", sender);
+                        debug!("    Payload: {:?}", hex::encode(payload));
+                    }
                     my_node_runtime::substratee_registry::RawEvent::ShieldFunds(
                         incognito_account,
                     ) => {


### PR DESCRIPTION
produce one block confirmation per layer one block
(maybe just one block confirmation if an actual indirect call is executed is better?)