### PR TITLE
Sidechain reenable indirect invocation

### DIFF
--- a/client/demo_direct_call.sh
+++ b/client/demo_direct_call.sh
@@ -13,7 +13,7 @@
 # then run this script
 
 # usage:
-#  demo_direct_call.sh <NODEPORT> <WORKERPORT> <WORKERRPCPORT>
+#  demo_direct_call.sh <NODEPORT> <WORKERRPCPORT>
 
 # using default port if none given as arguments
 NPORT=${1:-9944}

--- a/client/demo_private_tx.sh
+++ b/client/demo_private_tx.sh
@@ -2,19 +2,30 @@
 
 # setup:
 # run all on localhost:
-# run substratee-node --dev --ws-port 9979 -lruntime=debug
-# run substratee-worker -p 9979 run
+#   substratee-node purge-chain --dev
+#   substratee-node --tmp --dev -lruntime=debug
+#   rm chain_relay_db.bin
+#   substratee-worker init_shard
+#   substratee-worker shielding-key
+#   substratee-worker signing-key
+#   substratee-worker run
 #
 # then run this script
 
-CLIENT="./substratee-client -p 9979 -P 2079"
+# usage:
+#  demo_private_tx.sh <NODEPORT> <WORKERRPCPORT>
 
-echo "query on-chain enclave registry:"
-$CLIENT list-workers
+# using default port if none given as arguments
+NPORT=${1:-9944}
+RPORT=${3:-2000}
+
+echo "Using node-port ${NPORT}"
+echo "Using worker-rpc-port ${RPORT}"
 echo ""
 
-# does this work when multiple workers are in the registry?
-read MRENCLAVE <<< $($CLIENT list-workers | awk '/  MRENCLAVE:[[:space:]]/ { print $2 }')
+CLIENT="./../bin/substratee-client -p ${NPORT} -P ${RPORT}"
+# SW mode - hardcoded MRENCLAVE!
+read MRENCLAVE <<< $(cat ~/mrenclave.b58)
 
 # only for initial setup (actually should be done in genesis)
 # pre-fund //AliceIncognito, our ROOT key
@@ -22,12 +33,6 @@ echo "issue funds on first (sender) account:"
 $CLIENT trusted set-balance //AliceIncognito 123456789 --mrenclave $MRENCLAVE
 echo -n "get balance: "
 $CLIENT trusted balance //AliceIncognito --mrenclave $MRENCLAVE
-
-## create a new on-chain account and fund it form faucet
-#account1=$($CLIENT new-account)
-#echo "*** created new on-chain account: $account1"
-#echo "*** funding that account from faucet"
-#$CLIENT faucet $account1 
 
 # create incognito account for default shard (= MRENCLAVE)
 account1p=$($CLIENT trusted new-account --mrenclave $MRENCLAVE)

--- a/enclave/src/lib.rs
+++ b/enclave/src/lib.rs
@@ -391,11 +391,21 @@ pub unsafe extern "C" fn produce_blocks(
                 return sgx_status_t::SGX_ERROR_UNEXPECTED;
             }
 
-            // get indirect worker calls from blocks
+            // execute indirect calls, incl. shielding and unshielding
             match scan_block_for_relevant_xt(&signed_block.block) {
+                // push shield funds to opaque calls
                 Ok(c) => calls.extend(c.into_iter()),
                 Err(_) => error!("Error executing relevant extrinsics"),
             };
+            // compose indirect block confirmation
+            let xt_block = [SUBSRATEE_REGISTRY_MODULE, BLOCK_CONFIRMED];
+            let genesis_hash = validator.genesis_hash(validator.num_relays).unwrap();
+            let block_hash = signed_block.block.header.hash();
+            let prev_state_hash = signed_block.block.header.parent_hash();
+            calls.push(OpaqueCall(
+                (xt_block, genesis_hash, block_hash, prev_state_hash.encode()).encode(),
+            ));
+
         }
     }
     // get header of last block
@@ -767,16 +777,18 @@ pub fn update_states(header: Header) -> SgxResult<()> {
 }
 
 /// Scans blocks for extrinsics that ask the enclave to execute some actions.
+/// Executes indirect invocation calls, aswell as shielding and unshielding calls
+/// Returns all unshielding call confirmations as opaque calls
 pub fn scan_block_for_relevant_xt(block: &Block) -> SgxResult<Vec<OpaqueCall>> {
     debug!("Scanning block {} for relevant xt", block.header.number());
-    let mut calls = Vec::<OpaqueCall>::new();
+    let mut opaque_calls = Vec::<OpaqueCall>::new();
     for xt_opaque in block.extrinsics.iter() {
         if let Ok(xt) =
             UncheckedExtrinsicV4::<ShieldFundsFn>::decode(&mut xt_opaque.encode().as_slice())
         {
             // confirm call decodes successfully as well
             if xt.function.0 == [SUBSRATEE_REGISTRY_MODULE, SHIELD_FUNDS] {
-                if let Err(e) = handle_shield_funds_xt(&mut calls, xt) {
+                if let Err(e) = handle_shield_funds_xt(&mut opaque_calls, xt) {
                     error!("Error performing shieldfunds. Error: {:?}", e);
                 }
             }
@@ -795,30 +807,22 @@ pub fn scan_block_for_relevant_xt(block: &Block) -> SgxResult<Vec<OpaqueCall>> {
                         Stf::init_state()
                     };
                     // call execution
-                    match handle_trusted_worker_call(
-                        &mut calls,
+                    if let Err(e) = handle_trusted_worker_call(
+                        &mut opaque_calls, // necessary for unshielding
                         &mut state,
                         decrypted_trusted_call,
                         block.header.clone(),
                         shard,
                         None,
                     ) {
-                        Err(e) => error!("Error performing worker call: Error: {:?}", e),
-                        Ok(maybe_hashes) => {
-                            if let Some((call_hash, _)) = maybe_hashes {
-                                let xt_call = [SUBSRATEE_REGISTRY_MODULE, CALL_CONFIRMED];
-                                let state_hash = state::write(state, &shard)?;
-                                calls.push(OpaqueCall(
-                                    (xt_call, shard, call_hash, state_hash.encode()).encode(),
-                                ));
-                            }
-                        }
+                        error!("Error performing worker call: Error: {:?}", e);
                     }
                 }
             }
         }
     }
-    Ok(calls)
+
+    Ok(opaque_calls)
 }
 
 fn handle_shield_funds_xt(

--- a/enclave/src/lib.rs
+++ b/enclave/src/lib.rs
@@ -817,6 +817,8 @@ pub fn scan_block_for_relevant_xt(block: &Block) -> SgxResult<Vec<OpaqueCall>> {
                     ) {
                         error!("Error performing worker call: Error: {:?}", e);
                     }
+                    // save updated state
+                    state::write(state, &shard)?;
                 }
             }
         }

--- a/stf/src/lib.rs
+++ b/stf/src/lib.rs
@@ -46,11 +46,12 @@ pub type AuthorityId = <Signature as Verify>::Signer;
 pub type AccountId = AccountId32;
 pub type Hash = sp_core::H256;
 pub type BalanceTransferFn = ([u8; 2], AccountId, Compact<u128>);
-pub static BALANCE_MODULE: u8 = 4u8;
-pub static BALANCE_TRANSFER: u8 = 0u8;
+//FIXME: Is this really necessary to define all variables three times?
+//pub static BALANCE_MODULE: u8 = 4u8;
+//pub static BALANCE_TRANSFER: u8 = 0u8;
 pub static SUBSRATEE_REGISTRY_MODULE: u8 = 8u8;
-pub static UNSHIELD: u8 = 5u8;
-pub static CALL_CONFIRMED: u8 = 3u8;
+pub static UNSHIELD: u8 = 6u8;
+//pub static CALL_CONFIRMED: u8 = 3u8;
 
 pub type ShardIdentifier = H256;
 

--- a/substratee-node-primitives/src/lib.rs
+++ b/substratee-node-primitives/src/lib.rs
@@ -21,6 +21,7 @@ pub struct Request {
 
 pub type SubstrateeConfirmCallFn = ([u8; 2], ShardIdentifier, H256, Vec<u8>);
 pub type ShieldFundsFn = ([u8; 2], Vec<u8>, u128, ShardIdentifier);
+pub type CallWorkerFn = ([u8; 2], Request);
 
 #[cfg(feature = "std")]
 pub mod calls {

--- a/worker/src/main.rs
+++ b/worker/src/main.rs
@@ -478,6 +478,14 @@ fn print_events(events: Events, _sender: Sender<String>) {
                         debug!("    From:    {:?}", sender);
                         debug!("    Payload: {:?}", hex::encode(payload));
                     }
+                    my_node_runtime::substratee_registry::RawEvent::BlockConfirmed(
+                        sender,
+                        payload,
+                    ) => {
+                        info!("[+] Received BlockConfirmed event");
+                        debug!("    From:    {:?}", sender);
+                        debug!("    Payload: {:?}", hex::encode(payload));
+                    }
                     my_node_runtime::substratee_registry::RawEvent::ShieldFunds(
                         incognito_account,
                     ) => {


### PR DESCRIPTION
Reenables indirect invocation, with block confirmation instead of call confirmation

Current Problem that should be fixed in the future: for every individual indirect call the shard state is loaded and written. Very ineffective..

Is that acceptable for now?